### PR TITLE
Less layers by joining commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,8 @@ ENV DEBIAN_FRONTEND noninteractive
 # the install command below if using the above PPA as the gcc package has
 # everything included.
 
-# Fetch package repository
-RUN apt-get update
-
-# Upgrade all system packages to latest available version
-RUN apt-get -y dist-upgrade
+# Fetch package repository and upgrade all system packages to latest available version
+RUN apt-get update && apt-get -y dist-upgrade
 
 # native platform development and build system functionality (about 400 MB installed)
 RUN apt-get -y install \

--- a/native/Dockerfile
+++ b/native/Dockerfile
@@ -31,11 +31,8 @@ MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-# Fetch package repository
-RUN apt-get update
-
-# Upgrade all system packages to latest available version
-RUN apt-get -y dist-upgrade
+# Fetch package repository and upgrade all system packages to latest available version
+RUN apt-get update && apt-get -y dist-upgrade
 
 # native platform development and build system functionality (about 400 MB installed)
 RUN apt-get -y install \


### PR DESCRIPTION
Each `RUN` command in the Dockerfile adds a file system layer to the container. Joining commands on a single line using `&&` results in less layers and less overhead.

This joins the update and dist-upgrade commands on a single line, there is really no use for them as separate layers.