### PR TITLE
added GNU parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get -y install \
     git \
     graphviz \
     libpcre3 \
+    parallel \
     pcregrep \
     python \
     python3 \


### PR DESCRIPTION
The new drone build script uses GNU parallel to speed up the build process (See https://github.com/RIOT-OS/RIOT/pull/3038)