### PR TITLE
gcc 4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ ENV DEBIAN_FRONTEND noninteractive
 # the install command below if using the above PPA as the gcc package has
 # everything included.
 
+# Add backports repository for gcc-arm-none-eabi 4.9 on jessie
 # Fetch package repository and upgrade all system packages to latest available version
-RUN apt-get update && apt-get -y dist-upgrade
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+    /etc/apt/sources.list.d/backports.list && \
+    apt-get update && apt-get -y dist-upgrade
 
 # native platform development and build system functionality (about 400 MB installed)
 RUN apt-get -y install \
@@ -93,6 +96,8 @@ RUN apt-get -y install \
 RUN apt-get -y install \
     qemu-system-x86
 
+# Create working directory for mounting the RIOT sources
 RUN mkdir -p /data/riotbuild
+
 WORKDIR /data/riotbuild
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ RUN apt-get -y install \
     wget
 
 # Cortex-M development (about 550 MB installed)
-RUN apt-get -y install \
+RUN apt-get -t jessie-backports -y install \
+    binutils-arm-none-eabi \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi \
     libstdc++-arm-none-eabi-newlib \

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -31,7 +31,8 @@ ENV DEBIAN_FRONTEND noninteractive
 #RUN apt-get update
 
 # Cortex-M development (about 550 MB installed)
-RUN apt-get -y install \
+RUN apt-get -t jessie-backports -y install \
+    binutils-arm-none-eabi \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi \
     libstdc++-arm-none-eabi-newlib \

--- a/native/Dockerfile
+++ b/native/Dockerfile
@@ -12,27 +12,17 @@
 # 3. cd to riot root
 # 4. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
 
-# Ubuntu 14.04
-#FROM ubuntu:trusty
-# Ubuntu 14.10
-#FROM ubuntu:utopic
-# Ubuntu 15.04
-#FROM ubuntu:vivid
-# same as jessie?
-#FROM debian:testing
-# same as testing?
 FROM debian:jessie
-# Debian unstable
-#FROM debian:sid
-# probably not a good idea to use this for your build needs.
-#FROM debian:experimental
 
 MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Add backports repository for gcc-arm-none-eabi 4.9 on jessie
 # Fetch package repository and upgrade all system packages to latest available version
-RUN apt-get update && apt-get -y dist-upgrade
+RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
+    /etc/apt/sources.list.d/backports.list && \
+    apt-get update && apt-get -y dist-upgrade
 
 # native platform development and build system functionality (about 400 MB installed)
 RUN apt-get -y install \


### PR DESCRIPTION
This updates the gcc-arm-none-eabi version in the Docker image to 4.9 via the jessie-backports repository.

Wait until libstdc++-arm-none-eabi-newlib_4.9.2-21+7 hits the Debian package repository before merging.

see:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=787913
https://packages.debian.org/ca/jessie-backports/libstdc++-arm-none-eabi-newlib