### PR TITLE
add bsdutils (hexdump) to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN echo 'deb http://httpredir.debian.org/debian jessie-backports main' > \
 
 # native platform development and build system functionality (about 400 MB installed)
 RUN apt-get -y install \
+    bsdmainutils \
     build-essential \
     curl \
     cppcheck \


### PR DESCRIPTION
Since we merged RIOT-OS/RIOT#3229 ```hexdump``` is needed for building the unit tests.