### PR TITLE
arm+native: Add clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,8 @@ RUN apt-get -y install \
 
 # LLVM/Clang build environment (about 125 MB installed)
 RUN apt-get -y install \
-    llvm
+    llvm \
+    clang
 
 # x86 bare metal emulation (about 125 MB installed) (this pulls in all of X11)
 RUN apt-get -y install \

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get -t jessie-backports -y install \
 
 # LLVM/Clang build environment (about 125 MB installed)
 RUN apt-get -y install \
-    llvm
+    llvm \
+    clang
 
 RUN mkdir -p /data/riotbuild
 WORKDIR /data/riotbuild

--- a/native/Dockerfile
+++ b/native/Dockerfile
@@ -42,7 +42,8 @@ RUN apt-get -y install \
 
 # # LLVM/Clang build environment (about 125 MB installed)
 # RUN apt-get -y install \
-#     llvm
+#     llvm \
+#     clang
 
 RUN mkdir -p /data/riotbuild
 WORKDIR /data/riotbuild


### PR DESCRIPTION
The llvm package does not contain the main clang binary on Debian.

The original intention of the llvm package in the Dockerfiles was to provide clang inside the containers.