### PR TITLE
docker: add global system-wide git user and email address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,5 +102,9 @@ RUN apt-get -y install \
 # Create working directory for mounting the RIOT sources
 RUN mkdir -p /data/riotbuild
 
+# Set a global system-wide git user and email address
+RUN git config --system user.name "riot" && \
+    git config --system user.email "riot@example.com"
+
 WORKDIR /data/riotbuild
 


### PR DESCRIPTION
This PR sets up a global user and email address for git.
Rationale: When using docker to build a test that requires a package with patches, then
the patching returns the following error:
```
fatal: unable to look up current user in the passwd file: no such user
You need to set your committer info first
```
Can be invoked by issueing
```
BUILD_IN_DOCKER=1 BOARD=native make distclean clean all
```
in the `$(RIOTBASE)/tests/coap` folder.