### PR TITLE
Add signal wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ FROM debian:jessie
 # probably not a good idea to use this for your build needs.
 #FROM debian:experimental
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,5 +106,8 @@ RUN mkdir -p /data/riotbuild
 RUN git config --system user.name "riot" && \
     git config --system user.email "riot@example.com"
 
-WORKDIR /data/riotbuild
+# Copy our entry point script (signal wrapper)
+COPY run.sh /run.sh
+ENTRYPOINT ["/bin/bash", "/run.sh"]
 
+WORKDIR /data/riotbuild

--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM riot/riotbuild:native-only
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/avr/Dockerfile
+++ b/avr/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM riot/riotbuild:native-only
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/msp430/Dockerfile
+++ b/msp430/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM riot/riotbuild:native-only
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/native/Dockerfile
+++ b/native/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:jessie
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/native/Dockerfile
+++ b/native/Dockerfile
@@ -45,6 +45,14 @@ RUN apt-get -y install \
 #     llvm \
 #     clang
 
-RUN mkdir -p /data/riotbuild
-WORKDIR /data/riotbuild
+# Set a global system-wide git user and email address
+RUN git config --system user.name "riot" && \
+    git config --system user.email "riot@example.com"
 
+RUN mkdir -p /data/riotbuild
+
+# Copy our entry point script (signal wrapper)
+COPY run.sh /run.sh
+ENTRYPOINT ["/bin/bash", "/run.sh"]
+
+WORKDIR /data/riotbuild

--- a/native/run.sh
+++ b/native/run.sh
@@ -13,7 +13,7 @@ terminateall() {
 }
 
 runcommand() {
-    "$@" &
+    "$@" <&0 &
     masterpid="$!"
     trap "terminateall $masterpid" EXIT SIGINT SIGTERM
 

--- a/native/run.sh
+++ b/native/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# A wrapper to trap the SIGINT and SIGTERM signals (Ctrl+C, kill) and forwards
+# it to the child process as a SIGTERM
+# Idea: https://github.com/docker-library/mysql/issues/47#issuecomment-147397851
+# Further reading: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
+
+terminateall() {
+    for p in "$@"
+    do
+        echo "Stopping PID $p"
+        kill -SIGTERM $p >/dev/null 2>/dev/null
+    done
+}
+
+runcommand() {
+    "$@" &
+    masterpid="$!"
+    trap "terminateall $masterpid" EXIT SIGINT SIGTERM
+
+    # Wait for the top level child process to terminate
+    while kill -0 $masterpid > /dev/null 2>&1; do
+        wait
+    done
+}
+
+runcommand "$@"
+
+# no need to run the EXIT handler on a clean exit
+trap - EXIT

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ terminateall() {
 }
 
 runcommand() {
-    "$@" &
+    "$@" <&0 &
     masterpid="$!"
     trap "terminateall $masterpid" EXIT SIGINT SIGTERM
 

--- a/run.sh
+++ b/run.sh
@@ -16,14 +16,20 @@ runcommand() {
     "$@" <&0 &
     masterpid="$!"
     trap "terminateall $masterpid" EXIT SIGINT SIGTERM
+    retval="0"
 
     # Wait for the top level child process to terminate
     while kill -0 $masterpid > /dev/null 2>&1; do
-        wait
+        wait $masterpid
+        retval="$?"
     done
+    return "$retval"
 }
 
 runcommand "$@"
+status="$?"
 
 # no need to run the EXIT handler on a clean exit
 trap - EXIT
+
+exit "$status"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# A wrapper to trap the SIGINT and SIGTERM signals (Ctrl+C, kill) and forwards
+# it to the child process as a SIGTERM
+# Idea: https://github.com/docker-library/mysql/issues/47#issuecomment-147397851
+# Further reading: https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/
+
+terminateall() {
+    for p in "$@"
+    do
+        echo "Stopping PID $p"
+        kill -SIGTERM $p >/dev/null 2>/dev/null
+    done
+}
+
+runcommand() {
+    "$@" &
+    masterpid="$!"
+    trap "terminateall $masterpid" EXIT SIGINT SIGTERM
+
+    # Wait for the top level child process to terminate
+    while kill -0 $masterpid > /dev/null 2>&1; do
+        wait
+    done
+}
+
+runcommand "$@"
+
+# no need to run the EXIT handler on a clean exit
+trap - EXIT

--- a/x86/Dockerfile
+++ b/x86/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM riot/riotbuild:native-only
 
-MAINTAINER Joakim Gebart <joakim.gebart@eistec.se>
+MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Sometimes when pressing ctrl-c to abort a build the container doesn't exit and one make process usually starts to use 100% cpu in an infinite loop. This seem to be caused by not handling signals properly. This script adds a signal handler for SIGTERM (kill) and SIGINT (ctrl-c) to ask the subprocesses to terminate before exiting.

Tested on my own machine, both ctrl-c and kill, both directed at the top level sh process and the make and the gcc processes. I have not had a single case of stuck processes so far.

Bonus commit: Changed my last name where I could find it.