### PR TITLE
dockerfile: add native gdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN \
         cppcheck \
         doxygen \
         gcc-multilib \
+        gdb \
         g++-multilib \
         git \
         graphviz \


### PR DESCRIPTION
static-tests are probably soon running "make term" through gdb in order to see backtraces.