### PR TITLE
add tool to create a passwd entry for user running the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,12 @@ RUN \
     && echo 'Cleaning up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# compile suid create_user binary
+COPY create_user.c /tmp/create_user.c
+RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.c -o /usr/local/bin/create_user \
+    && chown root:root /usr/local/bin/create_user \
+    && chmod u=rws,g=x,o=- /usr/local/bin/create_user
+
 # Create working directory for mounting the RIOT sources
 RUN mkdir -p /data/riotbuild
 

--- a/create_user.c
+++ b/create_user.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        return 1;
+    }
+
+    setuid(0);
+
+    unsigned uid = atoi(argv[1]);
+    char buf[128];
+
+    sprintf(buf, "/usr/sbin/useradd -u %u -d %s -r -g 0 -N %s", uid, HOMEDIR, USERNAME);
+    system(buf);
+    return 0;
+}

--- a/run.sh
+++ b/run.sh
@@ -26,6 +26,10 @@ runcommand() {
     return "$retval"
 }
 
+# create passwd entry for current uid, fix HOME variable
+create_user $(id -u)
+export HOME=/data/riotbuild
+
 if [ $# = 0 ]; then
     echo "$0: No command specified" >&2
     # docker run also exits with error code 125 when no command is specified and


### PR DESCRIPTION
This PR makes sure that the uid executing a command within the container has a proper passwd entry.

This solves some trouble with stuff requiring a user entry:

```
I have no name!@984e0102d179:/data/riotbuild$ ssh booze
No user exists for uid 1000
I have no name!@984e0102d179:/data/riotbuild$
```

vs.

```
riotbuild@bb9627754a88:~$ ssh booze
The authenticity of host 'booze (192.168.1.150)' can't be established.
ECDSA key fingerprint is SHA256:JgfpYCuH13M74r4kJnRt+yegIdQq5F5BW68FADcYf1I.
Are you sure you want to continue connecting (yes/no)?
```