### PR TITLE
dockerfile: add ccache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     apt-get -y install \
         bsdmainutils \
         build-essential \
+        ccache \
         cmake \
         curl \
         cppcheck \


### PR DESCRIPTION
Currently, Murdock is copying a [ccache](https://github.com/RIOT-OS/murdock-scripts) binary into the docker image at runtime.
@kaspar030 was there any reasoning to use a local binary instead of using ccache from upstream?