### PR TITLE
misc improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,8 @@ ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
 COPY create_user.c /tmp/create_user.c
 RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.c -o /usr/local/bin/create_user \
     && chown root:root /usr/local/bin/create_user \
-    && chmod u=rws,g=x,o=- /usr/local/bin/create_user
+    && chmod u=rws,g=x,o=- /usr/local/bin/create_user \
+    && rm /tmp/create_user.c
 
 # Create working directory for mounting the RIOT sources
 RUN mkdir -p /data/riotbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.
     && rm /tmp/create_user.c
 
 # Create working directory for mounting the RIOT sources
-RUN mkdir -p /data/riotbuild
+RUN mkdir -m 777 -p /data/riotbuild
 
 # Set a global system-wide git user and email address
 RUN git config --system user.name "riot" && \


### PR DESCRIPTION
Here's a small collection of fixes for our Docker image:

1. cut off the cleaning step of the package installation phase

This is more a developing aid. Every time something needs to be added, a full re-installation of all packages is needed. With this PR, it becomes possible to just install packages after the main bunch, making use of docker's caching, saving a lot of time.

2. /tmp/create_user.c is leftover but unneeded

3. /data/riotbuild can not be written to if not overmounted using "docker run -v". There are use-cases where this causes trouble.