### PR TITLE
Openocd support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,9 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" -DSHELL=\"/bin/ba
 # Create working directory for mounting the RIOT sources
 RUN mkdir -p /data/riotbuild
 
+# Change ownership of /data/riotbuild from root to default user
+RUN chown 1000:1000 /data/riotbuild
+
 # Set a global system-wide git user and email address
 RUN git config --system user.name "riot" && \
     git config --system user.email "riot@example.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
 
 # compile suid create_user binary
 COPY create_user.c /tmp/create_user.c
-RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.c -o /usr/local/bin/create_user \
+RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" -DSHELL=\"/bin/bash\" /tmp/create_user.c -o /usr/local/bin/create_user \
     && chown root:root /usr/local/bin/create_user \
     && chmod u=rws,g=x,o=- /usr/local/bin/create_user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,9 @@ RUN mkdir -p /data/riotbuild
 RUN git config --system user.name "riot" && \
     git config --system user.email "riot@example.com"
 
+# Simple root password in case we want to customize the container
+RUN echo "root:root" | chpasswd
+
 # Copy our entry point script (signal wrapper)
 COPY run.sh /run.sh
 ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/build_openocd.sh
+++ b/build_openocd.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+SCRIPT_PATH=`readlink -f $0`
+SCRIPT_DIR=`dirname $SCRIPT_PATH`
+
+# Configuration env vars will be set to default values if not defined.
+[ -z $OPENOCD_TOP_DIR ] && OPENOCD_TOP_DIR=$SCRIPT_DIR
+[ -z $OPENOCD_VERSION ] && OPENOCD_VERSION="master"
+[ -z $OPENOCD_INSTALL_PREFIX ] && OPENOCD_INSTALL_PREFIX="/usr/local"
+[ -z $OPENOCD_CONFIGURE_OPTS ] && OPENOCD_CONFIGURE_OPTS="--enable-cmsis-dap"
+[ -z $OPENOCD_J_LEVEL ] && OPENOCD_J_LEVEL=`nproc`
+[ -z $OPENOCD_GIT_URL ] && OPENOCD_GIT_URL="git://git.code.sf.net/p/openocd/code"
+[ -z $OPENOCD_WORKING_DIR ] && OPENOCD_WORKING_DIR="openocd"
+
+# Enter the top build dir
+pushd $OPENOCD_TOP_DIR
+
+# Clone and build openocd
+git clone $OPENOCD_GIT_URL $OPENOCD_WORKING_DIR
+[ $? -ne 0 ] && >&2 echo "ERROR: Unable to clone git repo $OPENOCD_GIT_URL" && exit 1
+pushd $OPENOCD_WORKING_DIR
+git checkout $OPENOCD_VERSION
+[ $? -ne 0 ] && >&2 echo "ERROR: Unable to checkout git revision $OPENOCD_VERSION" && exit 1
+./bootstrap
+[ $? -ne 0 ] && >&2 echo "ERROR: openocd bootstrap fail!" && exit 1
+./configure --prefix $OPENOCD_INSTALL_PREFIX $OPENOCD_CONFIGURE_OPTS
+[ $? -ne 0 ] && >&2 echo "ERROR: openocd configure fail!" && exit 1
+make && make install
+[ $? -ne 0 ] && >&2 echo "ERROR: openocd build fail!" && exit 1
+popd
+
+# Generate environment setup script.
+# This script can be sourced by the user if the prefix is a local directory.
+cat << EOF > $OPENOCD_INSTALL_PREFIX/setup-openocd-env
+export PATH=$OPENOCD_INSTALL_PREFIX/bin:\$PATH
+export LD_LIBRARY_PATH=$OPENOCD_INSTALL_PREFIX/lib
+EOF
+
+popd #pushd $OPENOCD_TOP_DIR

--- a/create_user.c
+++ b/create_user.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
     unsigned uid = atoi(argv[1]);
     char buf[128];
 
-    sprintf(buf, "/usr/sbin/useradd -u %u -d %s -r -g 0 -N %s", uid, HOMEDIR, USERNAME);
+    sprintf(buf, "/usr/sbin/useradd -u %u -d %s -r -g 0 -N %s -s %s", uid, HOMEDIR, USERNAME, SHELL);
     system(buf);
     return 0;
 }

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+#
+
+# Fix for running GUI programs from within the docker container:
+# Make xorg disable access control, i.e. let any x client connect to our
+# server.
+xhost +
+
+docker run -it \
+	--privileged \
+	-v /tmp/.X11-unix:/tmp/.X11-unix \
+	-v /dev/bus/usb:/dev/bus/usb \
+	-e DISPLAY=unix$DISPLAY \
+	-u `id -u` \
+	--name riot \
+	riotbuild

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+# Fix for running GUI programs from within the docker container:
+# Make xorg disable access control, i.e. let any x client connect to our
+# server.
+xhost +
+
+docker start -ai riot


### PR DESCRIPTION
Enable OpenOCD support in the docker container.

OpenOCD is built from source instead of using the binary package from the Ubuntu apt repo.
Rationale: Get an as up-to-date version of OpenOCD as possible.

I have tested the patches with an Arduino Zero board.