### PR TITLE
Dockerfile: add python3 crypto libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ RUN \
         python \
         python3 \
         python3-pexpect \
+        python3-crypto \
+        python3-pyasn1 \
+        python3-ecdsa \
         p7zip \
         subversion \
         unzip \


### PR DESCRIPTION
Python3 crypto libraries are needed for Murdock to generate standard crypto keys in order to sign valid images.

For now this is only used for MCUBoot support.