### PR TITLE
add vim-common, which provides /usr/bin/xxd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN \
         p7zip \
         subversion \
         unzip \
+        vim-common \
         wget \
     && echo 'Installing Cortex-M toolchain' >&2 && \
     apt-get -y install \


### PR DESCRIPTION
needed by https://github.com/RIOT-OS/RIOT/pull/7794 in order to create a C header file containing the data of arbitrary files as char array.