### PR TITLE
add pep8 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN \
         python3-crypto \
         python3-pyasn1 \
         python3-ecdsa \
+        python3-pep8 \
         p7zip \
         subversion \
         unzip \


### PR DESCRIPTION
This adds the pep8 command dependency as required for https://github.com/RIOT-OS/RIOT/pull/8036.