### PR TITLE
add travis automatic build on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: generic
+sudo: required
+
+services:
+  - docker
+
+script: docker build -t riotdocker .


### PR DESCRIPTION
Not sure if it's worth it but I think it would be great to have some kind of build check of the Docker image when one introduces new packages, etc

This PR just add a travis configuration file that just triggers a new build of the Docker image. If accepted, we'll have to setup the travis integration.

~We could even publish new images automatically on successful builds (only from master branch of course).~