### PR TITLE
dependencies: add automake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN \
     apt-get update && apt-get -y dist-upgrade \
     && echo 'Installing native toolchain and build system functionality' >&2 && \
     apt-get -y install \
+        automake \
         bsdmainutils \
         build-essential \
         ccache \


### PR DESCRIPTION
This PR adds `automake` to the RIOT docker image. It's (at least) required for building OpenThread.