### PR TITLE
toolchain for ESP8266

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN echo 'Adding esp8266 toolchain' >&2 && \
     cd /opt && \
     git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp && \
     cd esp && \
-    git checkout v1.0
+    git checkout -q df38b06 
 
 ENV PATH $PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,12 +128,13 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.
     && chmod u=rws,g=x,o=- /usr/local/bin/create_user \
     && rm /tmp/create_user.c
 
-# Installs the complete ESP8266 toolchain in /opt/esp (170 MB after cleanup) from binaries
+# Installs the complete ESP8266 toolchain in /opt/esp (146 MB after cleanup) from binaries
 RUN echo 'Adding esp8266 toolchain' >&2 && \
     cd /opt && \
     git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp && \
     cd esp && \
-    git checkout -q df38b06 
+    git checkout -q df38b06 && \
+    rm -rf .git 
 
 ENV PATH $PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,15 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.
     && chmod u=rws,g=x,o=- /usr/local/bin/create_user \
     && rm /tmp/create_user.c
 
+# Installs the complete ESP8266 toolchain in /opt/esp (170 MB after cleanup) from binaries
+RUN echo 'Adding esp8266 toolchain' >&2 && \
+    cd /opt && \
+    git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp && \
+    cd esp && \
+    git checkout v1.0
+
+ENV PATH $PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
+
 # Create working directory for mounting the RIOT sources
 RUN mkdir -m 777 -p /data/riotbuild
 


### PR DESCRIPTION
I have added build commands for ESP8266 toolchain as required for my EPS8266 port of RIOT, see PR [#8921](https://github.com/RIOT-OS/RIOT/pull/8921).

The toolchain is located in ```/opt/esp``` after installation and requires approximately 140 MB. Path variables in make point to this directory per default. 

I guess, adding ESP8266 toolchain to riotdocker is also a prerequisite for murdock test. Am I right?