### PR TITLE
Add xsltproc to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN \
         unzip \
         vim-common \
         wget \
+        xsltproc \
     && echo 'Installing MSP430 toolchain' >&2 && \
     apt-get -y install \
         gcc-msp430 \


### PR DESCRIPTION
From the xsltproc website:

> xsltproc is a command line tool for applying XSLT stylesheets to XML documents. It is part of libxslt, the XSLT C library for GNOME. While it was developed as part of the GNOME project, it can operate independently of the GNOME desktop.

This is necessary e.g. for https://github.com/RIOT-OS/RIOT/pull/7903 and possibly other packages in the future.