### PR TITLE
esp8266: toolchain changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN \
         python3-pyasn1 \
         python3-ecdsa \
         python3-flake8 \
+        python-serial \
         p7zip \
         subversion \
         unzip \
@@ -128,8 +129,11 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.
     && chmod u=rws,g=x,o=- /usr/local/bin/create_user \
     && rm /tmp/create_user.c
 
-# Installs the complete ESP8266 toolchain in /opt/esp (146 MB after cleanup) from binaries
-RUN echo 'Adding esp8266 toolchain' >&2 && \
+# add user riotbuild to group dialout to permit the access to serial usb devices
+RUN useradd -G dialout riotbuild
+
+# Install complete ESP8266 toolchain in /opt/esp (146 MB after cleanup)
+RUN echo 'Installing ESP8266 toolchain' >&2 && \
     cd /opt && \
     git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp && \
     cd esp && \


### PR DESCRIPTION
When I was trying not only to build ESP8266 images with riotdocker, but also to flash them, I realized that there are two additional requirements:

1. The python module for serial port access has to installed
2. The access to host's USB serial ports has to be permitted.

While requirement 1 is probabely specific for the ESP8266 toolchain, requirement 2 might also has to be fulfilled for other toolchains.

I made the following changes:

- to fulfill requirement 1, package ```python-serial``` is installed
- to fulfill requirement 2, user ```riotbuild``` is added to group ```dialout```

Starting the container by command
```
docker run -i -t --privileged -v /dev:/dev -u $UID -v $(pwd):/data/riotbuild riotbuild
```
then permits the access to host's USB serial devices, e.g., ```/dev/ttyUSB0```. Thus, riotdocker ca also be used to flash the image.