### PR TITLE
mips: Upgrade toolchain to version 2017.10-08

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN wget -q https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz -O- \
 
 # Install MIPS binary toolchain
 RUN mkdir -p /opt && \
-        wget -q http://codescape-mips-sdk.imgtec.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
+        wget -q http://codescape.mips.com/components/toolchain/2017.10-07/Codescape.GNU.Tools.Package.2017.10-07.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
         | tar -C /opt -xz
 
 ENV PATH $PATH:/opt/mips-mti-elf/2016.05-03/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,8 @@ RUN mkdir -p /opt && \
         wget -q http://codescape.mips.com/components/toolchain/2017.10-07/Codescape.GNU.Tools.Package.2017.10-07.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
         | tar -C /opt -xz
 
-ENV PATH $PATH:/opt/mips-mti-elf/2016.05-03/bin
-ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
+ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2017.10-08
+ENV PATH ${PATH}:${MIPS_ELF_ROOT}/bin
 
 # Install RISC-V binary toolchain
 RUN mkdir -p /opt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN wget -q https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz -O- \
     make && make install && cd && rm -rf /tmp/cmake-3.10.0
 
 # Install MIPS binary toolchain
+# For updates: https://www.mips.com/develop/tools/codescape-mips-sdk/ (select "Codescape GNU Toolchain")
 RUN mkdir -p /opt && \
         wget -q 'https://codescape.mips.com/components/toolchain/2017.10-08/Codescape.GNU.Tools.Package.2017.10-08.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz' -O- \
         | tar -C /opt -xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN wget -q https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz -O- \
 
 # Install MIPS binary toolchain
 RUN mkdir -p /opt && \
-        wget -q http://codescape.mips.com/components/toolchain/2017.10-07/Codescape.GNU.Tools.Package.2017.10-07.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
+        wget -q 'https://codescape.mips.com/components/toolchain/2017.10-08/Codescape.GNU.Tools.Package.2017.10-08.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz' -O- \
         | tar -C /opt -xz
 
 ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2017.10-08


### PR DESCRIPTION
This PR fixes the MIPS toolchain link, as stated in #46 

### Issues/PRs references ###

Tracking the needed changes to update the toolchain: https://github.com/RIOT-OS/RIOT/pull/10009