### PR TITLE
Dockerfile: add missing Openthread dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN \
         git \
         graphviz \
         libpcre3 \
+        libtool \
         parallel \
         pcregrep \
         python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN \
         graphviz \
         libpcre3 \
         libtool \
+        m4 \
         parallel \
         pcregrep \
         python \


### PR DESCRIPTION
This PR adds `libtool` and `m4`, required for building OpenThread.
I tried to build OpenThread with and without this PR, and this fixes the issue.

~It was rebased into #47~
Since #50 got merged, this should work now!