### PR TITLE
Dockerfile: add vera++

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ RUN \
         ssh-client \
         subversion \
         unzip \
+        vera++ \
         vim-common \
         wget \
         xsltproc \


### PR DESCRIPTION
This adds [Vera++](https://bitbucket.org/verateam/vera/wiki/Introduction) to the installation. The CI script to run the check can be found in RIOT-OS/RIOT#9778.