### PR TITLE
Deduplicate binaries and remove toolchain documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,10 @@ RUN mkdir -p /opt && \
         wget -q https://codescape.mips.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
         | tar -C /opt -xz && \
     echo 'Removing documentation and translations' >&2 && \
-    rm -rf /opt/mips-mti-elf/*/share/{doc,info,man,locale}
+    rm -rf /opt/mips-mti-elf/*/share/{doc,info,man,locale} && \
+    echo 'Deduplicating binaries' >&2 && \
+    cd /opt/mips-mti-elf/*/mips-mti-elf/bin && \
+    for f in *; do rm "$f" && ln "../../bin/mips-mti-elf-$f" "$f"; done && cd -
 
 ENV PATH $PATH:/opt/mips-mti-elf/2016.05-03/bin
 ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,9 @@ RUN wget -q https://cmake.org/files/v3.10/cmake-3.10.0.tar.gz -O- \
 # Install MIPS binary toolchain
 RUN mkdir -p /opt && \
         wget -q https://codescape.mips.com/components/toolchain/2016.05-03/Codescape.GNU.Tools.Package.2016.05-03.for.MIPS.MTI.Bare.Metal.CentOS-5.x86_64.tar.gz -O- \
-        | tar -C /opt -xz
+        | tar -C /opt -xz && \
+    echo 'Removing documentation and translations' >&2 && \
+    rm -rf /opt/mips-mti-elf/*/share/{doc,info,man,locale}
 
 ENV PATH $PATH:/opt/mips-mti-elf/2016.05-03/bin
 ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,10 @@ RUN mkdir -p /opt && \
         wget -q https://github.com/gnu-mcu-eclipse/riscv-none-gcc/releases/download/v7.2.0-2-20180110/gnu-mcu-eclipse-riscv-none-gcc-7.2.0-2-20180111-2230-centos64.tgz -O- \
         | tar -C /opt -xz && \
     echo 'Removing documentation' >&2 && \
-    rm -rf /opt/gnu-mcu-eclipse/riscv-none-gcc/*/share/doc
+    rm -rf /opt/gnu-mcu-eclipse/riscv-none-gcc/*/share/doc && \
+    echo 'Deduplicating binaries' >&2 && \
+    cd /opt/gnu-mcu-eclipse/riscv-none-gcc/*/riscv-none-embed/bin && \
+    for f in *; do rm "$f" && ln "../../bin/riscv-none-embed-$f" "$f"; done && cd -
 
 # HACK download arch linux' flex dynamic library
 RUN wget -q https://sgp.mirror.pkgbuild.com/core/os/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz -O- \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,8 @@ RUN mkdir -p /opt && \
     cd /opt/mips-mti-elf/*/mips-mti-elf/bin && \
     for f in *; do rm "$f" && ln "../../bin/mips-mti-elf-$f" "$f"; done && cd -
 
-ENV PATH $PATH:/opt/mips-mti-elf/2016.05-03/bin
 ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
+ENV PATH ${PATH}:${MIPS_ELF_ROOT}/bin
 
 # Install RISC-V binary toolchain
 RUN mkdir -p /opt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,9 @@ ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
 # Install RISC-V binary toolchain
 RUN mkdir -p /opt && \
         wget -q https://github.com/gnu-mcu-eclipse/riscv-none-gcc/releases/download/v7.2.0-2-20180110/gnu-mcu-eclipse-riscv-none-gcc-7.2.0-2-20180111-2230-centos64.tgz -O- \
-        | tar -C /opt -xz
+        | tar -C /opt -xz && \
+    echo 'Removing documentation' >&2 && \
+    rm -rf /opt/gnu-mcu-eclipse/riscv-none-gcc/*/share/doc
 
 # HACK download arch linux' flex dynamic library
 RUN wget -q https://sgp.mirror.pkgbuild.com/core/os/x86_64/flex-2.6.4-1-x86_64.pkg.tar.xz -O- \


### PR DESCRIPTION
This saves around ~~70-80 MB~~ 130 MB in the finished image.

These toolchain binaries are hard links to the same file when installed from source. I think there was some mistake when the tar archives were made that failed to preserve the hard links and instead stores them as separate files. The toolchain tar archive for Cortex-M from ARM _does_ preserve the hard link property, so this file duplication has to be a mistake in the packaging for the RISC-V and MIPS toolchains.

Verified locally that these duplicate files have the same sha1 signature.