### PR TITLE
travis: print build size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ sudo: required
 services:
   - docker
 
-script: docker build -t riotdocker .
+script:
+  - docker build -t riotdocker .
+  - docker image ls riotdocker:latest


### PR DESCRIPTION
Print image build size after building it.
This should help debug build size increase.

### Testing

Check travis output to see if it prints it correctly.