### PR TITLE
use python pip to install required packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,7 @@ RUN \
         pcregrep \
         python \
         python3 \
-        python3-pexpect \
-        python3-crypto \
-        python3-pyasn1 \
-        python3-ecdsa \
-        python3-flake8 \
+        python3-pip \
         p7zip \
         subversion \
         unzip \
@@ -85,6 +81,12 @@ RUN \
         libsocketcan2:i386 \
     && echo 'Cleaning up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# install required python packages from file
+COPY pydeps.txt /tmp/pydeps.txt
+RUN echo 'Installing python3 packages' >&2 \
+    && pip3 install -r /tmp/pydeps.txt \
+    && rm /tmp/pydeps.txt
 
 # Install ARM GNU embedded toolchain
 # For updates, see https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads

--- a/pydeps.txt
+++ b/pydeps.txt
@@ -1,0 +1,5 @@
+asn1
+ecdsa
+flake8
+pexpect
+pycrypto


### PR DESCRIPTION
This changes the install procedure for python packages from using APT packages to use python-pip and install packages from a file. This has several advantages:

- not all pythons deps for RIOT are available as APT packages (see Murdocks `dwq` for instance)
- installing from file makes dependencies more explicit
- and also allows to specify (and fix) package version (if needed)
