### PR TITLE
apt: Use --no-install-recommends to avoid unnecessary extras 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,11 @@ RUN \
     echo 'Upgrading all system packages to the latest available versions' >&2 && \
     apt-get update && apt-get -y dist-upgrade \
     && echo 'Installing native toolchain and build system functionality' >&2 && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends install \
         automake \
         bsdmainutils \
         build-essential \
+        ca-certificates \
         ccache \
         coccinelle \
         curl \
@@ -50,6 +51,7 @@ RUN \
         g++-multilib \
         git \
         graphviz \
+        less \
         libpcre3 \
         libtool \
         m4 \
@@ -64,25 +66,28 @@ RUN \
         python3-flake8 \
         python-serial \
         p7zip \
+        rsync \
+        ssh-client \
         subversion \
         unzip \
         vim-common \
         wget \
         xsltproc \
     && echo 'Installing MSP430 toolchain' >&2 && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends install \
         gcc-msp430 \
+        msp430-libc \
     && echo 'Installing AVR toolchain' >&2 && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends install \
         gcc-avr \
         binutils-avr \
         avr-libc \
     && echo 'Installing LLVM/Clang toolchain' >&2 && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends install \
         llvm \
         clang \
     && echo 'Installing socketCAN' >&2 && \
-    apt-get -y install \
+    apt-get -y --no-install-recommends install \
         libsocketcan-dev:i386 \
         libsocketcan2:i386 \
     && echo 'Cleaning up installation files' >&2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN gcc -DHOMEDIR=\"/data/riotbuild\" -DUSERNAME=\"riotbuild\" /tmp/create_user.
     && chmod u=rws,g=x,o=- /usr/local/bin/create_user \
     && rm /tmp/create_user.c
 
-# Install complete ESP8266 toolchain in /opt/esp (146 MB after cleanup) 
+# Install complete ESP8266 toolchain in /opt/esp (146 MB after cleanup)
 RUN echo 'Installing ESP8266 toolchain' >&2 && \
     cd /opt && \
     git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp && \


### PR DESCRIPTION
Add `--no-install-recommends` to apt-get commands to avoid pulling in optional dependencies which are not used by the build process. 

The image size reduction is approximately 430 MB
```
REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
riot/riotbuild             norecommends        402547be3514        3 minutes ago       3.34 GB
riot/riotbuild             master              e4c568fc283a        44 minutes ago      3.77 GB
```

## Testing

This needs a full buildtest run on the new image to ensure that no critical components are missing after adding this flag, but my laptop does not have the disk space or time to do it.