### PR TITLE
add package: lsb-release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN \
         less \
         libpcre3 \
         libtool \
+        lsb-release \
         m4 \
         parallel \
         pcregrep \


### PR DESCRIPTION
## Description

The static tests use `/etc/os-release` to report the OS version in Linux. This file is not standard: it is present in all systems with systemd and maybe other distros too. The lsb_release tool, on the other hand, is standardized as part of Linux Standard Base and should be the "correct" way to detect the OS version.

## Related PRs

Needed by https://github.com/RIOT-OS/RIOT/pull/10770