### PR TITLE
create /etc/riotbuild_version with "git describe --always" output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -284,4 +284,19 @@ ENTRYPOINT ["/bin/bash", "/run.sh"]
 # By default, run a shell when no command is specified on the docker command line
 CMD ["/bin/bash"]
 
+# get Dockerfile version from build args
+ARG RIOTBUILD_VERSION=unknown
+ENV RIOTBUILD_VERSION $RIOTBUILD_VERSION
+
+ARG RIOTBUILD_COMMIT=unknown
+ENV RIOTBUILD_COMMIT $RIOTBUILD_COMMIT
+
+ARG RIOTBUILD_BRANCH=unknown
+ENV RIOTBUILD_BRANCH $RIOTBUILD_BRANCH
+
+# watch for single ">" vs double ">>"!
+RUN echo "RIOTBUILD_VERSION=$RIOTBUILD_VERSION" > /etc/riotbuild
+RUN echo "RIOTBUILD_COMMIT=$RIOTBUILD_COMMIT" >> /etc/riotbuild
+RUN echo "RIOTBUILD_BRANCH=$RIOTBUILD_BRANCH" >> /etc/riotbuild
+
 WORKDIR /data/riotbuild

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker build \
+    --build-arg RIOTBUILD_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+    --build-arg RIOTBUILD_COMMIT="$(git rev-parse HEAD)" \
+    --build-arg RIOTBUILD_VERSION="$(git describe --always)" \
+    -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}" .


### PR DESCRIPTION
Currently, there's no way to get the git commit of the running docker container from within the container.

This PR uses Docker hub magic (namely, a custom build hook) to get the output of "git describe" into the container image.

See https://github.com/docker/hub-feedback/issues/600 for others having similar issue and solution.