### PR TITLE
add Dockerfile to build riotbuild image with opeoncd

### DIFF
--- a/Dockerfile.openocd
+++ b/Dockerfile.openocd
@@ -1,0 +1,24 @@
+FROM riot/riotbuild
+
+# Install openocd dependencies
+RUN apt-get update && apt-get -y dist-upgrade \
+    && apt-get -y --no-install-recommends install \
+    libhidapi-hidraw0 \
+    libhidapi-dev \
+    libusb-1.0 \
+    pkg-config
+
+# Build openocd from source
+RUN mkdir -p opt \
+    && cd /opt \
+    && git clone --depth 1 https://github.com/ntfreak/openocd.git \
+    && cd openocd \
+    && ./bootstrap \
+    && ./configure --enable-stlink --enable-jlink --enable-ftdi --enable-cmsis-dap \
+    && make -j"$(nproc)" \
+    && make install-strip \
+    && cd .. \ 
+    && rm -rf openocd \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /data/riotbuild

--- a/Dockerfile.openocd
+++ b/Dockerfile.openocd
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get -y dist-upgrade \
     libhidapi-hidraw0 \
     libhidapi-dev \
     libusb-1.0 \
+    libudev-devi \
     pkg-config
 
 # Build openocd from source
@@ -17,7 +18,7 @@ RUN mkdir -p opt \
     && ./configure --enable-stlink --enable-jlink --enable-ftdi --enable-cmsis-dap \
     && make -j"$(nproc)" \
     && make install-strip \
-    && cd .. \ 
+    && cd .. \
     && rm -rf openocd \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds a Dockerfile to add openocd to the riotbuild. This allow a user to compile, flash and access a terminal all threw docker. The only requirements would be adding udev rules to /etc/udev/rules.d.

It adds 180Mb to the docker image size, from 3.5Gb ---> 3.76Gb

For now you need to add "--privileged" when flashing, but this could be wrapped in the RIOT makefiles (RIOT-OS/RIOT#11220).

### Testing procedure

Build Image:

`docker build -t riotflash -f Dockerfile.openocd .
`

Compile and Flash:

`docker run --rm -i -t --privileged -v $(pwd):/data/riotbuild riotflash make -C /data/riotbuild/examples/hello-world BOARD=nucleo-l152re flash
`

Open terminal:

`docker run --rm -i -t --device=/tty/ACM0 --group-add plugdev  -v $(pwd):/data/riotbuild riotflash make -C /data/riotbuild/examples/hello-world BOARD=nucleo-l152re term
`

NOTE: the docker image in docker hub is 4 month old, not up to date with the latest changes changes is Dockerfile.
NOTE2: the commands above assume that the new image is riotflash, it could be riot/riotbuildv2 or whatever

### Issues/PRs references

#30 