### PR TITLE
esp32: fix toolchain download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,12 +167,10 @@ ENV PATH $PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
 RUN echo 'Installing ESP32 toolchain' >&2 && \
     mkdir -p /opt/esp && \
     cd /opt/esp && \
-    git clone --recursive https://github.com/espressif/esp-idf.git && \
+    git clone https://github.com/espressif/esp-idf.git && \
     cd esp-idf && \
     git checkout -q f198339ec09e90666150672884535802304d23ec && \
-    cd components/esp32/lib && \
-    git checkout -q 534a9b14101af90231d40a4f94924d67bc848d5f && \
-    cd /opt/esp/esp-idf && \
+    git submodule update --init --recursive && \
     rm -rf .git* docs examples make tools && \
     rm -f add_path.sh CONTRIBUTING.rst Kconfig Kconfig.compiler && \
     cd components && \


### PR DESCRIPTION
The current way of first recursively cloneing the esp-idf-repo, then setting the wanted commit, doesn't work. Some of the submodules have advanced too far. The result is that building the current Dockerfile fails.

This PR fixes this by first cloning un-recursively, setting the wanted commit, then clone the submodules from a known state.