### PR TITLE
update riscv toolchain to 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,21 +134,21 @@ ENV MIPS_ELF_ROOT /opt/mips-mti-elf/2016.05-03
 ENV PATH ${PATH}:${MIPS_ELF_ROOT}/bin
 
 # Install RISC-V binary toolchain
+ARG RISCV_VERSION=8.2.0-2.2-20190521
+ARG RISCV_BUILD=0004
 RUN mkdir -p /opt && \
-        wget -q https://github.com/gnu-mcu-eclipse/riscv-none-gcc/releases/download/v7.2.0-2-20180110/gnu-mcu-eclipse-riscv-none-gcc-7.2.0-2-20180111-2230-centos64.tgz -O- \
+        wget -q https://github.com/gnu-mcu-eclipse/riscv-none-gcc/releases/download/v${RISCV_VERSION}/gnu-mcu-eclipse-riscv-none-gcc-${RISCV_VERSION}-${RISCV_BUILD}-centos64.tgz -O- \
         | tar -C /opt -xz && \
     echo 'Removing documentation' >&2 && \
-    rm -rf /opt/gnu-mcu-eclipse/riscv-none-gcc/*/share/doc && \
+      rm -rf /opt/gnu-mcu-eclipse/riscv-none-gcc/*/share/doc && \
     echo 'Deduplicating binaries' >&2 && \
     cd /opt/gnu-mcu-eclipse/riscv-none-gcc/*/riscv-none-embed/bin && \
-    for f in *; do rm "$f" && ln "../../bin/riscv-none-embed-$f" "$f"; done && cd -
+      for f in *; do test -f "../../bin/riscv-none-embed-$f" && \
+       ln -f "../../bin/riscv-none-embed-$f" "$f"; \
+      done && \
+    cd -
 
-# HACK download arch linux' flex dynamic library
-RUN wget -q https://sgp.mirror.pkgbuild.com/core/os/x86_64/flex-2.6.4-2-x86_64.pkg.tar.xz -O- \
-        | tar -C / -xJ usr/lib/libfl.so.2.0.0
-RUN ldconfig
-
-ENV PATH $PATH:/opt/gnu-mcu-eclipse/riscv-none-gcc/7.2.0-2-20180111-2230/bin
+ENV PATH $PATH:/opt/gnu-mcu-eclipse/riscv-none-gcc/${RISCV_VERSION}-${RISCV_BUILD}/bin
 
 # compile suid create_user binary
 COPY create_user.c /tmp/create_user.c


### PR DESCRIPTION
The current risc-v toolchain makes some applications not pass the tests.
This gcc 8.1 based one works fine. I didn't dig for reasons. My gut feeling is that the newly available newlib-nano saves enough stack space to not break the tests.

Supercedes #62.
~~Waiting for #70.~~