### PR TITLE
travis: add riot testbuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,16 @@ services:
 script:
   - docker build -t riotdocker .
   - docker image ls riotdocker:latest
+  - git clone --depth 1 https://github.com/RIOT-OS/RIOT -b 2019.04
+  # Fix for https://github.com/RIOT-OS/RIOT/pull/11385.
+  # Needed until that fix is part of the release mentioned above.
+  - sed -i '35i\ \ BOARDS \\' RIOT/makefiles/docker.inc.mk
+  - DOCKER_IMAGE=riotdocker:latest
+    BUILD_IN_DOCKER=1
+    BOARDS="arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"
+    make -CRIOT/examples/hello-world buildtest
+  - DOCKER_IMAGE=riotdocker:latest
+    TOOLCHAIN=llvm
+    BUILD_IN_DOCKER=1
+    BOARDS="native samr21-xpro"
+    make -CRIOT/examples/hello-world buildtest


### PR DESCRIPTION
This PR tries to add a build of hello-world for all installed toolchains.

The idea is to get a basic notion of whether the container is able to build RIOT.
I have randomly selected one board for each installed toolchain.