### PR TITLE
add python dependencies for SUIT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ flake8==3.5.0
 pexpect==4.2.1
 pycrypto==2.6.1
 pyserial==3.4
+ed25519==1.4
+cbor==1.0.0
+cryptography==2.6.1


### PR DESCRIPTION
This PR adds needed dependencies for SUIT (https://github.com/RIOT-OS/RIOT/pull/11818)

To test, make sure docker is correctly installed.

Then:

- check out this PR
- build the container (eg. ```docker build -t riotdocker_dev .```)
- check out #11818
- from the checkout root, run ```riot (suit-pr)]$ docker run -ti --rm -v $(pwd):/data/riotbuild -u $(id -u) riotdocker_dev /bin/bash```
- in the container, ```cd examples/suit_update; make suit/publish```

It should succeed.
Otherwise this shouldn't affect anything, as this is only an addition of python packages.
