### PR TITLE
[Docker] replace deprecated MAINTAINER with LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 FROM ubuntu:bionic
 
-MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
+LABEL maintainer="Joakim Nohlgård <joakim.nohlgard@eistec.se>"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 FROM ubuntu:bionic
 
-LABEL maintainer="Joakim Nohlgård <joakim.nohlgard@eistec.se>"
+LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Reference
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated