### PR TITLE
add ENV LC_ALL|LANG=C.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ MAINTAINER Joakim Nohlgård <joakim.nohlgard@eistec.se>
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
 # The following package groups will be installed:
 # - upgrade all system packages to latest available version
 # - native platform development and build system functionality (about 400 MB installed)


### PR DESCRIPTION
This somewhat ensures a consistent utf-8 configuration.

Without any LANG or LC_ALL setting, Linux systems default to the C locale. This breaks many utf8 applications. Most notably, python is much more sane when running in utf8 locales.

(See #73 , https://github.com/RIOT-OS/RIOT/issues/11691)