### PR TITLE
Add scapy as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyserial==3.4
 ed25519==1.4
 cbor==1.0.0
 cryptography==2.6.1
+scapy>=2.4.3


### PR DESCRIPTION
I use `scapy` generally for network tests. Version 2.4.3 includes the MQTT-SN support [I provided to the scapy project](https://github.com/secdev/scapy/pull/2131) which is required for https://github.com/RIOT-OS/RIOT/pull/11823 (and a soon-to-be-provided `asymcute` version of that test).