### PR TITLE
python: keep setuptools during installation of python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN \
         python3 \
         python3-dev \
         python3-pip \
+        python3-setuptools \
+        python3-wheel \
         p7zip \
         rsync \
         ssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,13 +96,9 @@ RUN \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install required python packages from file
-COPY install_requirements.txt /tmp/install_requirements.txt
 COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 \
-    && pip3 install --no-cache-dir -r /tmp/install_requirements.txt \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
-    && pip3 uninstall -y -r /tmp/install_requirements.txt \
-    && rm /tmp/install_requirements.txt \
     && rm /tmp/requirements.txt
 
 # Install ARM GNU embedded toolchain

--- a/install_requirements.txt
+++ b/install_requirements.txt
@@ -1,2 +1,0 @@
-setuptools==39.0.1
-wheel==0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 pyasn1==0.4.2
 ecdsa==0.13
 flake8==3.5.0
+setuptools==39.0.1
+wheel==0.30.0
 pexpect==4.2.1
 pycrypto==2.6.1
 pyserial==3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 pyasn1==0.4.2
 ecdsa==0.13
 flake8==3.5.0
-setuptools==39.0.1
-wheel==0.30.0
 pexpect==4.2.1
 pycrypto==2.6.1
 pyserial==3.4


### PR DESCRIPTION
Should fix https://github.com/RIOT-OS/RIOT/issues/12058 when deployed on the workers. I'm also wondering if the `install_requirements.txt` file is really needed.