### PR TITLE
add msp430-gcc-elf version 9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,10 @@ ENV PATH $PATH:/opt/esp/xtensa-esp32-elf/bin
 # Install msp430-elf-gcc
 # see https://aur.archlinux.org/packages/msp430-elf-gcc
 
+# silence autotools/make
+ENV GNUMAKEFLAGS=--no-print-directory
+ENV V=0
+
 ENV MSP430_GCC_BINUTILS_VER=2.32
 ENV MSP430_GCC_BINUTILS_SHA=0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
 RUN mkdir -p /mspgcc && \
@@ -197,7 +201,9 @@ RUN mkdir -p /mspgcc && \
     cd /mspgcc/binutils-$MSP430_GCC_BINUTILS_VER && \
     mkdir binutils-build && \
     cd binutils-build && \
-    ../configure --target=msp430-elf \
+    ../configure \
+      --silent \
+      --target=msp430-elf \
       --prefix=/usr \
       --disable-nls \
       --program-prefix=msp430-elf- \
@@ -208,9 +214,10 @@ RUN mkdir -p /mspgcc && \
       --build=$CHOST \
       --disable-shared \
       --enable-lto && \
+
     make configure-host && \
     make && \
-    make install && \
+    make  install && \
     rm -rf /mspgcc/binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz /mspgcc/binutils-$MSP430_GCC_BINUTILS_VER
 
 ENV MSP430_GCC_VER=9.2.0
@@ -246,6 +253,7 @@ RUN CFLAGS="-O2 -pipe" CXXFLAGS="-O2 -pipe" CFLAGS_FOR_TARGET="-Os -pipe" CXXFLA
     ls -ahl && \
     cd gcc-build && \
     ../configure \
+      --silent \
       --prefix=/usr \
       --program-prefix=msp430-elf- \
       --target=msp430-elf \
@@ -279,6 +287,7 @@ RUN CFLAGS_FOR_TARGET="-Os -g -ffunction-sections -fdata-sections" mkdir -p /msp
     mkdir newlib-build && \
     cd newlib-build && \
     ../configure \
+     --silent \
      --prefix=/usr \
      --target=msp430-elf \
      --disable-newlib-supplied-syscalls \
@@ -292,7 +301,7 @@ RUN CFLAGS_FOR_TARGET="-Os -g -ffunction-sections -fdata-sections" mkdir -p /msp
      --enable-lite-exit \
      --enable-newlib-global-atexit \
      --disable-nls && \
-   make -j1 && \
+   make  && \
    make install && \
    mkdir -p /usr/msp430-elf/usr && \
    ln -sf /usr/msp430-elf/include /usr/msp430-elf/usr/include && \
@@ -308,6 +317,7 @@ RUN cd /mspgcc/gcc-$MSP430_GCC_VER && \
     ls -ahl && \
     cd gcc-build && \
     ../configure \
+      --silent \
       --prefix=/usr \
       --program-prefix=msp430-elf- \
       --target=msp430-elf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,7 +191,7 @@ ENV MSP430_GCC_BINUTILS_VER=2.32
 ENV MSP430_GCC_BINUTILS_SHA=0ab6c55dd86a92ed561972ba15b9b70a8b9f75557f896446c82e8b36e473ee04
 RUN mkdir -p /mspgcc && \
     cd /mspgcc && \
-    curl -o binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz ftp://ftp.gnu.org/gnu/binutils/binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz && \
+    curl -L -o binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz https://ftp.gnu.org/gnu/binutils/binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz && \
     echo "$MSP430_GCC_BINUTILS_SHA binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz" | sha256sum -c - && \
     tar xJf binutils-${MSP430_GCC_BINUTILS_VER}.tar.xz && \
     cd /mspgcc/binutils-$MSP430_GCC_BINUTILS_VER && \
@@ -227,14 +227,14 @@ RUN apt-get update && \
 # download isl sources
 RUN mkdir -p /mspgcc && \
     cd /mspgcc && \
-    curl -o isl-${MSP430_GCC_ISL_VER}.tar.xz http://isl.gforge.inria.fr/isl-${MSP430_GCC_ISL_VER}.tar.xz && \
+    curl -L -o isl-${MSP430_GCC_ISL_VER}.tar.xz http://isl.gforge.inria.fr/isl-${MSP430_GCC_ISL_VER}.tar.xz && \
     echo "$MSP430_GCC_ISL_SHA isl-$MSP430_GCC_ISL_VER.tar.xz" | sha256sum -c - && \
     tar xJf isl-${MSP430_GCC_ISL_VER}.tar.xz
 
 # download gcc sources
 RUN mkdir -p /mspgcc && \
     cd /mspgcc && \
-    curl -o gcc-${MSP430_GCC_VER}.tar.xz ftp://gcc.gnu.org/pub/gcc/releases/gcc-${MSP430_GCC_VER}/gcc-${MSP430_GCC_VER}.tar.xz && \
+    curl -L -o gcc-${MSP430_GCC_VER}.tar.xz https://gcc.gnu.org/pub/gcc/releases/gcc-${MSP430_GCC_VER}/gcc-${MSP430_GCC_VER}.tar.xz && \
     echo "$MSP430_GCC_SHA gcc-$MSP430_GCC_VER.tar.xz" | sha256sum -c - && \
     tar xJf gcc-${MSP430_GCC_VER}.tar.xz
 
@@ -272,7 +272,7 @@ ENV MSP430_GCC_NEWLIB_VER=3.1.0
 ENV MSP430_GCC_NEWLIB_SHA=fb4fa1cc21e9060719208300a61420e4089d6de6ef59cf533b57fe74801d102a
 RUN CFLAGS_FOR_TARGET="-Os -g -ffunction-sections -fdata-sections" mkdir -p /mspgcc && \
     cd /mspgcc && \
-    curl -o newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz ftp://sourceware.org/pub/newlib/newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz && \
+    curl -o newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz https://sourceware.org/pub/newlib/newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz && \
     echo "$MSP430_GCC_NEWLIB_SHA newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz" | sha256sum -c - && \
     tar xzf newlib-${MSP430_GCC_NEWLIB_VER}.tar.gz && \
     cd /mspgcc/newlib-${MSP430_GCC_NEWLIB_VER} && \


### PR DESCRIPTION
this commit adds the gcc 9.2 compiler for the msp430 targets.
inspired by https://aur.archlinux.org/packages/msp430-elf-gcc/