### PR TITLE
add protobuf-compiler as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ed25519==1.4
 cbor==1.0.0
 cryptography==2.6.1
 scapy>=2.4.3
+protobuf-compiler>=3.0.0


### PR DESCRIPTION
When using the nanopb package, a version of protoc is needed to generate .c and header files from the protobuf definitions.
This adds protoc to riotdocker.

Needed for https://github.com/RIOT-OS/RIOT/pull/11565