### PR TITLE
Dockerfile: install protobuf-compiler via apt package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN \
         m4 \
         parallel \
         pcregrep \
+        protobuf-compiler \
         python \
         python3 \
         python3-dev \


### PR DESCRIPTION
When using the nanopb package, a version of protoc is needed to generate .c and header files from the protobuf definitions.
This adds protoc to riotdocker.

Needed for https://github.com/RIOT-OS/RIOT/pull/11565