### PR TITLE
Dockerfile: add codespell dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN \
         ccache \
         cmake \
         coccinelle \
+        codespell \
         curl \
         cppcheck \
         doxygen \


### PR DESCRIPTION
This PR adds the codespell dependency to the container: it is required for https://github.com/RIOT-OS/RIOT/pull/12232