### PR TITLE
travis: bump travis to bionic, RIOT release to 2019.07-branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 sudo: required
+dist: bionic
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ services:
 script:
   - docker build -t riotdocker .
   - docker image ls riotdocker:latest
-  - git clone --depth 1 https://github.com/RIOT-OS/RIOT -b 2019.04
-  # Fix for https://github.com/RIOT-OS/RIOT/pull/11385.
-  # Needed until that fix is part of the release mentioned above.
-  - sed -i '35i\ \ BOARDS \\' RIOT/makefiles/docker.inc.mk
+  - git clone --depth 1 https://github.com/RIOT-OS/RIOT -b 2019.07-branch
   - DOCKER_IMAGE=riotdocker:latest
     BUILD_IN_DOCKER=1
     BOARDS="arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"


### PR DESCRIPTION
- change to use release branch instead of tag
- remove obsolete 2019.04 hack
- also bump travis container to use the bionic image (was using trusty from 14.04)