### PR TITLE
codespell: install via pip instead of apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN \
         ccache \
         cmake \
         coccinelle \
-        codespell \
         curl \
         cppcheck \
         doxygen \

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ed25519==1.4
 cbor==1.0.0
 cryptography==2.6.1
 scapy>=2.4.3
+codespell==1.16.0


### PR DESCRIPTION
Unfortunately the version of codespell installed by apt doesn't contain some of the options used in https://github.com/RIOT-OS/RIOT/pull/12232

This PR is installing codespell via pip3 with the latest current version (1.16) to be sure all required features can be used.