### PR TITLE
add libffi_dev (needed by python cffi)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN \
         git \
         graphviz \
         less \
+        libffi-dev \
         libpcre3 \
         libtool \
         m4 \


### PR DESCRIPTION
When building the container locally, it failed with missing `ffi.h` include while installing the python requirements:

```
    building '_cffi_backend' extension                                                                                             
    creating build/temp.linux-x86_64-3.6                                                                                           
    creating build/temp.linux-x86_64-3.6/c                                                                                         
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdat$
-time -D_FORTIFY_SOURCE=2 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/pyth$
n3.6m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.6/c/_cffi_backend.o                                                        
    c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory                                                         
     #include <ffi.h>                                                                                                              
              ^~~~~~~                                                                                                              
    compilation terminated.                                                                                                        
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1                                                                
                                                                                                                                   
    ----------------------------------------                                                                                       
Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-la5lm7cb/cffi/setup.py';f=getattr(tokenize, $
open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/$
ip-zf46m9ui-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-la$
lm7cb/cffi/                                                                                                                        
The command '/bin/sh -c echo 'Installing python3 packages' >&2     && pip3 install --no-cache-dir -r /tmp/requirements.txt     && $
m /tmp/requirements.txt' returned a non-zero code: 1                                                                               
```

Adding the `libffi-dev` ubuntu package fixed the issue.