### PR TITLE
add TI msp430 gcc 8.3.0 ELF/newlib toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,6 +198,13 @@ RUN echo 'Installing ESP32 toolchain' >&2 && \
 
 ENV PATH $PATH:/opt/esp/xtensa-esp32-elf/bin
 
+ARG MSP430_URL=https://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/latest/exports
+ARG MSP430_VERSION=8.3.0.16_linux64
+RUN echo 'Installing TI MSP430 ELF toolchain' >&2 && \
+        wget -q ${MSP430_URL}/msp430-gcc-${MSP430_VERSION}.tar.bz2 -O- \
+            | tar -C /opt -xj
+ENV PATH $PATH:/opt/msp430-gcc-${MSP430_VERSION}/bin
+
 # install required python packages from file
 COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 \


### PR DESCRIPTION
This PR adds the current official TI msp430 ELF toolchain.

@gschorcht @geromueller please take a look!

Compared to #82 , it avoids building the toolchain from source.
Compared to #62, this is using TI's current release, and does not install the support files.

PR to RIOT master updating msp430: RIOT-OS/RIOT#12457, which includes just the used msp430-support-files.

This PR will not do any compilation test on travis, as there's no code supporting this in master...