### PR TITLE
esp8266: toolchain update for the new RTOS SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,6 +172,34 @@ RUN echo 'Installing ESP8266 toolchain' >&2 && \
     rm -rf .git
 
 ENV PATH $PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
+ENV ESP8266_SDK_DIR /opt/esp/esp-open-sdk/sdk
+ENV ESP8266_NEWLIB_DIR /opt/esp/newlib-xtensa
+
+# Install complete ESP8266 toolchain in /opt/esp (139 MB after cleanup)
+# remember https://github.com/RIOT-OS/RIOT/pull/10801 when updating
+# NOTE: We install the toolchain for the RTOS SDK in parallel in the first
+# step and remove the old version as soon as the RIOT port for the ESP8266
+# RTOS SDK has been merged.
+RUN echo 'Installing ESP8266 toolchain' >&2 && \
+    mkdir -p /opt/esp && \
+    cd /opt/esp && \
+    git clone https://github.com/gschorcht/xtensa-esp8266-elf && \
+    cd xtensa-esp8266-elf && \
+    git checkout -q 696257c2b43e2a107d3108b2c1ca6d5df3fb1a6f && \
+    rm -rf .git && \
+    cd /opt/esp && \
+    git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-RTOS-SDK.git ESP8266_RTOS_SDK && \
+    cd ESP8266_RTOS_SDK/ && \
+    git checkout -q f074414c0705715a44b8e59d53b03d90b7630382 && \
+    rm -rf .git* docs examples make tools && \
+    cd components && \
+    rm -rf app_update aws_iot bootloader cjson coap espos esp-tls freertos \
+           jsmn libsodium log mdns mqtt newlib partition_table pthread \
+           smartconfig_ack spiffs ssl tcpip_adapter vfs && \
+    find . -name '*.[csS]' -exec rm {} \;
+
+ENV PATH $PATH:/opt/esp/xtensa-esp8266-elf/bin
+ENV ESP8266_RTOS_SDK_DIR /opt/esp/ESP8266_RTOS_SDK
 
 # Install ESP32 toolchain in /opt/esp (181 MB after cleanup)
 # remember https://github.com/RIOT-OS/RIOT/pull/10801 when updating


### PR DESCRIPTION
This PR adds a new ESP8266 toolchain that uses a newer GCC version and the new ESP8266 RTOS SDK instead of the old ESP8266 NONOS SDK. It is required for the reimplementation of the ESP8266 RIOT port in PR https://github.com/RIOT-OS/RIOT/pull/11108.

This new toolchain is installed in parallel to the old one to be able to compile the current master but also to compile the PR  https://github.com/RIOT-OS/RIOT/pull/11108. Once PR https://github.com/RIOT-OS/RIOT/pull/11108 is merged, the old toolchain can be removed.

The additional environment variable settings for the old toolchain are required to be able to divide the toolchain in RIOT's build system.