### PR TITLE
Dockerfile: install python-protobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN \
         pcregrep \
         protobuf-compiler \
         python \
+        python-protobuf \
         python3 \
         python3-dev \
         python3-pip \


### PR DESCRIPTION
Required for nanopb-0.4.0 (https://github.com/RIOT-OS/RIOT/pull/13228)