### PR TITLE
Dockerfile: install afl-gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN \
     apt-get update \
     && echo 'Installing native toolchain and build system functionality' >&2 && \
     apt-get -y --no-install-recommends install \
+        afl \
         automake \
         bsdmainutils \
         build-essential \


### PR DESCRIPTION
`afl-gcc` is needed for automatic build of fuzz tests.

https://github.com/RIOT-OS/RIOT/pull/13157#issuecomment-615264105