### PR TITLE
Update to Ubuntu 2020.04 LTS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.deb filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          lfs: 'true'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -26,6 +26,14 @@ LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 
 ENV DEBIAN_FRONTEND noninteractive
 
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+# copy some included packages
+RUN mkdir /pkgs
+COPY files/libsocketcan-dev_0.0.11-1_i386.deb /pkgs/libsocketcan-dev_0.0.11-1_i386.deb
+COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
+
 # The following package groups will be installed:
 # - update the package index files to latest available version
 # - native platform development and build system functionality (about 400 MB installed)
@@ -103,12 +111,10 @@ RUN \
         # Filter by symlinks starting with /usr/bin/llvm-${LLVM_VERSION}
         case "${SYMTARGET}" in "/usr/lib/llvm-${LLVM_VERSION}"* ) ln -sf ${SYMTARGET} ${SYMNAME}; esac \
     done \
-    && echo 'Installing socketCAN' >&2 && \
-    apt-get -y --no-install-recommends install \
-        libsocketcan-dev:i386 \
-        libsocketcan2:i386 \
+    && echo 'Installing local packages' >&2 && \
+        apt install -y --no-install-recommends /pkgs/*.deb \
     && echo 'Cleaning up installation files' >&2 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /pkgs
 
 # Install ARM GNU embedded toolchain
 # For updates, see https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -94,9 +94,9 @@ RUN \
         avr-libc \
     && echo 'Installing LLVM/Clang toolchain' >&2 && \
     apt-get -y --no-install-recommends install \
-        llvm-${LLVM_VERSION}/bionic-updates \
-        clang-${LLVM_VERSION}/bionic-updates \
-        clang-tools-${LLVM_VERSION}/bionic-updates \
+        llvm-${LLVM_VERSION} \
+        clang-${LLVM_VERSION} \
+        clang-tools-${LLVM_VERSION} \
         llvm \
         clang \
         clang-tools \

--- a/riotbuild/files/libsocketcan-dev_0.0.11-1_i386.deb
+++ b/riotbuild/files/libsocketcan-dev_0.0.11-1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e5d32040edb35388f4492ea4db10a00010e942a2139a20ede0b1e4d2e027e2f
+size 7588

--- a/riotbuild/files/libsocketcan2_0.0.11-1_i386.deb
+++ b/riotbuild/files/libsocketcan2_0.0.11-1_i386.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af122fcd407c139b83c283474c391a366e48c0648a190f621db2dc61f161ed5
+size 8172

--- a/riotdocker-base/Dockerfile
+++ b/riotdocker-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -8,12 +8,15 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
+# copy some included packages
+RUN mkdir /pkgs
+COPY files/coccinelle_1.0.8~19.04npalix1_amd64.deb /pkgs/coccinelle_1.0.8~19.04npalix1_amd64.deb
+
 RUN \
     echo 'Update the package index files to latest available versions' >&2 && \
     apt-get update && \
     echo 'Installing static test tools' >&2 && \
     apt-get -y --no-install-recommends install \
-        coccinelle \
         cppcheck \
         doxygen \
         graphviz \
@@ -25,8 +28,11 @@ RUN \
         vera++ \
         wget \
         && \
+    echo 'Installing local packages' >&2 && \
+    apt install -y --no-install-recommends /pkgs/*.deb \
+        && \
     echo 'Cleaning up installation files' >&2 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /pkgs
 
 # Install required Python packages
 COPY requirements.txt /tmp/requirements.txt

--- a/static-test-tools/files/coccinelle_1.0.8~19.04npalix1_amd64.deb
+++ b/static-test-tools/files/coccinelle_1.0.8~19.04npalix1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d929e93039deec2d04847f3e6b69916e66c1b8256816ad7dd01fca13db34b7
+size 5343420


### PR DESCRIPTION
This PR updates the base for our build container to Ubuntu focal (2020.04).

There's no coccinelle package anymore for focal in the coccinelle ppa, so I've added a binary package.
Same with libsocketcan.

In order to not clutter the git history with binary data, those package files have been added using git lfs, and the build.yml workflow has been adapted to pull the lfs files.

~~WIP, want to see travis output~~