### PR TITLE
bump travis RIOT version to 2020.04-branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 script:
   - docker build --pull -t riotdocker .
   - docker image ls riotdocker:latest
-  - git clone --depth 1 https://github.com/RIOT-OS/RIOT -b 2019.07-branch
+  - git clone --depth 1 https://github.com/RIOT-OS/RIOT -b 2020.04-branch
   - DOCKER_IMAGE=riotdocker:latest
     BUILD_IN_DOCKER=1
     BOARDS="arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"


### PR DESCRIPTION
#104 stumbled over a long fixed compilation issue because travis is still testing against 2019.07.

This PR updates the branch travis compiles against to 2020.04.