### PR TITLE
Dockerfile: install afl++ apt package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN \
     apt-get update \
     && echo 'Installing native toolchain and build system functionality' >&2 && \
     apt-get -y --no-install-recommends install \
+        afl++ \
         automake \
         bsdmainutils \
         build-essential \


### PR DESCRIPTION
This PR adds the afl toolchain to the dockdr image. It is required for building _fuzzing_ applications in RIOT.

Note that the afl toolchain is not tested on Murdock, see [here](https://github.com/RIOT-OS/RIOT/blob/379d113af79e57c4d0c1dad134014a507d779cbb/.murdock#L139-L140), but it is required when using `compile_and_test_for_board.py`:

For example, in RIOT:
```
BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications="fuzzing/*"
```

fails with the current Docker image because the afl toolchain is missing in the image.

<details><summary>with this PR:</summary>

```
BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications="fuzzing/*"
INFO:native:Saving toolchain
INFO:native.fuzzing/gcoap:Board supported: True
INFO:native.fuzzing/gcoap:Board has enough memory: True
INFO:native.fuzzing/gcoap:Application has test: False
INFO:native.fuzzing/gcoap:Run compilation
INFO:native.fuzzing/gcoap:Success
INFO:native.fuzzing/gnrc_tcp:Board supported: True
INFO:native.fuzzing/gnrc_tcp:Board has enough memory: True
INFO:native.fuzzing/gnrc_tcp:Application has test: False
INFO:native.fuzzing/gnrc_tcp:Run compilation
INFO:native.fuzzing/gnrc_tcp:Success
INFO:native:Tests successful
```

</details>

<details><summary>master:</summary>

```
BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . native --applications="fuzzing/*"
INFO:native:Saving toolchain
INFO:native.fuzzing/gcoap:Board supported: True
INFO:native.fuzzing/gcoap:Board has enough memory: True
INFO:native.fuzzing/gcoap:Application has test: False
INFO:native.fuzzing/gcoap:Run compilation
WARNING:native.fuzzing/gcoap:make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ./fuzzing/gcoap clean all
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=native' -e 'CC_NOCOLOR=1' -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/fuzzing/gcoap/' 'riot/riotbuild:latest' make 'CC_NOCOLOR=1' 'RIOT_CI_BUILD=1'    all
Compiler afl-gcc is required but not found in PATH.  Aborting.
/data/riotbuild/riotbase/Makefile.include:663: recipe for target '..compiler-check' failed
make: *** [..compiler-check] Error 1
make: *** [/work/riot/RIOT/makefiles/docker.inc.mk:305: ..in-docker-container] Error 2

Return value: 2

ERROR:native.fuzzing/gcoap:Error during compilation, writing to results/native/fuzzing/gcoap/compilation.failed
ERROR:native.fuzzing/gcoap:Failed during: compilation
INFO:native.fuzzing/gnrc_tcp:Board supported: True
INFO:native.fuzzing/gnrc_tcp:Board has enough memory: True
INFO:native.fuzzing/gnrc_tcp:Application has test: False
INFO:native.fuzzing/gnrc_tcp:Run compilation
WARNING:native.fuzzing/gnrc_tcp:make RIOT_CI_BUILD=1 CC_NOCOLOR=1 --no-print-directory -C ./fuzzing/gnrc_tcp clean all
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=native' -e 'CC_NOCOLOR=1' -e 'RIOT_CI_BUILD=1'  -w '/data/riotbuild/riotbase/fuzzing/gnrc_tcp/' 'riot/riotbuild:latest' make 'CC_NOCOLOR=1' 'RIOT_CI_BUILD=1'    all
Compiler afl-gcc is required but not found in PATH.  Aborting.
/data/riotbuild/riotbase/Makefile.include:663: recipe for target '..compiler-check' failed
make: *** [..compiler-check] Error 1
make: *** [/work/riot/RIOT/makefiles/docker.inc.mk:305: ..in-docker-container] Error 2

Return value: 2

ERROR:native.fuzzing/gnrc_tcp:Error during compilation, writing to results/native/fuzzing/gnrc_tcp/compilation.failed
ERROR:native.fuzzing/gnrc_tcp:Failed during: compilation
ERROR:native:Tests failed: 2
Failures during compilation:
- [fuzzing/gcoap](fuzzing/gcoap/compilation.failed)
- [fuzzing/gnrc_tcp](fuzzing/gnrc_tcp/compilation.failed)
```

</details>