### PR TITLE
Dockerfile: bump MIPS toolchain to 2020.06-01 (gcc 9.3.0)

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -126,7 +126,7 @@ ENV PATH ${PATH}:/opt/${ARM_FOLDER}/bin
 
 # Install MIPS binary toolchain
 # For updates: https://www.mips.com/develop/tools/codescape-mips-sdk/ (select "Codescape GNU Toolchain")
-ARG MIPS_VERSION=2018.09-03
+ARG MIPS_VERSION=2020.06-01
 RUN echo 'Installing mips-mti-elf toolchain from mips.com' >&2 && \
     mkdir -p /opt && \
     curl -L "https://codescape.mips.com/components/toolchain/${MIPS_VERSION}/Codescape.GNU.Tools.Package.${MIPS_VERSION}.for.MIPS.MTI.Bare.Metal.CentOS-6.x86_64.tar.gz" -o - \


### PR DESCRIPTION
Bump MIPS toolchain version to 2020.06-01 (gcc 9.3.0).

This breaks the build on the current RIOT version so we need to fix them on RIOT first.