### PR TITLE
picolibc: Add initial support for picolibc

### DIFF
--- a/cross-riscv-none-embed.txt
+++ b/cross-riscv-none-embed.txt
@@ -1,0 +1,17 @@
+[binaries]
+c = 'riscv-none-embed-gcc'
+ar = 'riscv-none-embed-ar'
+as = 'riscv-none-embed-as'
+strip = 'riscv-none-embed-strip'
+exe_wrapper = ['sh', '-c', 'test -z "$MESON_SOURCE_ROOT" || "$MESON_SOURCE_ROOT"/run-riscv "$@"', 'run-riscv']
+
+[host_machine]
+system = 'none'
+cpu_family = 'riscv'
+cpu = 'riscv'
+endian = 'little'
+
+[properties]
+c_args = [ '-nostdlib', '-msave-restore', '-fno-common' ]
+needs_exe_wrapper = true
+skip_sanity_check = true


### PR DESCRIPTION
Add support for picolibc in the docker image.

This builds the picolibc implementation for arm, esp32 and riscv32. The riscv implementation seems to work with RIOT-os/RIOT#12305, but I haven't tested it yet on actual hardware as I don't own one of the hifive boards.

Meson is grabbed from pip and not from the bionic repos because the version in bionic is too old (0.45 vs 0.50)

An alternative approach would be to simply grab the debian buster deb's and install those. Please let me know what is preferred here.