### PR TITLE
requirements.txt: add dependency to jinja2 template engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ protobuf==3.10.0
 scikit-learn==0.22.1
 joblib==0.14.0
 emlearn==0.10.1
+jinja2==2.11.2


### PR DESCRIPTION
It will be required by https://github.com/RIOT-OS/RIOT/pull/14595 and it's not available in the Docker image.