### PR TITLE
requirements.txt: add pyhsslms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ joblib==0.14.0
 emlearn==0.10.1
 jinja2==2.11.2
 riotctrl>=0.1.1
+pyhsslms>=1.0.0


### PR DESCRIPTION
The upstream suit-manifest-generator [requires](https://github.com/ARMmbed/suit-manifest-generator/blob/master/setup.py#L55) the pyhsslms package.
In order to use the upstream version as a package, also include this in riotdocker.

Needed for https://github.com/RIOT-OS/RIOT/pull/15095