### PR TITLE
CI: add bors configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,16 @@ os: linux
 services:
   - docker
 
+# settings needed by bors (see https://bors.tech/documentation/getting-started/)
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Uncomment this to enable building pull requests.
+    - master
+
 env:
   - RIOT_BRANCH=2021.01-branch
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = ["continuous-integration/travis-ci/push"]


### PR DESCRIPTION
This adds a minimal [bors](https://github.com/bors-ng/bors-ng) configuration.

> Do we want this one?

Pros:

    - no two PR can pass CI individually and then cause an error when merged ("
    - no need to rebase ACKed PRs, bors merges into master before testing
    - if multiple PR are ACKed at the same time, bors builds them together

Cons:

    - new tool (for us at least)
    - PR's actually show as closed even though bors merges their content, as bors merges it's staging branch
