### PR TITLE
requirements.txt: add colorama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pyserial==3.4
 ed25519==1.4
 cbor==1.0.0
 cbor2>=5.0.0
+colorama>=0.4.0
 cryptography==2.6.1
 scapy>=2.4.3
 codespell==1.16.0


### PR DESCRIPTION
The suit-manifest-generator script uses the [colorama](https://github.com/ARMmbed/suit-manifest-generator/blob/master/setup.py#L57) package.

In order to swich to the upstream version, also include it in our requirements.txt.

Needed for https://github.com/RIOT-OS/RIOT/pull/15095