### PR TITLE
travis: run static tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ script:
     BUILD_IN_DOCKER=1
     BOARDS="native samr21-xpro"
     make -CRIOT/examples/hello-world buildtest
+  # run static tests
+  - docker run --rm -ti -v $(pwd)/RIOT:/data/riotbuild -e CI_BASE_BRANCH=2020.04-branch riotdocker:latest ./dist/tools/ci/static_tests.sh


### PR DESCRIPTION
This PR adds running of the static tests to .travis.

Unfortunately RIOT's static tests pretty much assume to be run with changed files versus master, so this won't check *all* files, but *none*, if a reference branch is used by the specific test. All checks using "changed_files()" are affected.
But, babysteps...