### PR TITLE
requirements.txt: bump flake8 to 3.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Required python libraries
 pyasn1==0.4.2
 ecdsa==0.13.3
-flake8==3.5.0
+flake8==3.8.4
 pexpect==4.2.1
 pycrypto==2.6.1
 pyserial==3.4


### PR DESCRIPTION
This PR bumps the flake8 version used in the docker image, new version is less permissive with lint issues.