### PR TITLE
Dockerfile: add uncrustify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN \
         rsync \
         ssh-client \
         subversion \
+        uncrustify \
         unzip \
         vera++ \
         vim-common \


### PR DESCRIPTION
In https://github.com/RIOT-OS/RIOT/pull/15667 I noticed that `uncrustify` is not run in the static tests, since it isn't installed into our Docker. Here is the fix for that.