### PR TITLE
riotbuild: include rapidjson extras for riotctrl

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -15,5 +15,5 @@ scikit-learn==0.22.1
 joblib==0.14.0
 emlearn==0.10.1
 jinja2==2.11.2
-riotctrl>=0.1.1
+riotctrl[rapidjson]>=0.2.2
 pyhsslms>=1.0.0


### PR DESCRIPTION
The optional `rapidjson` dependency was added to `riotctrl` in https://github.com/RIOT-OS/riotctrl/pull/8 for a more lax parsing of JSON objects such as trailing commas within an object like this:

```json
{
  "one": 1,
  "two": 2,
  "three": {"I": "have", "more": "members",},
}
```

This adds that optional dependency. However, [dependency resolution was broken in `v0.2.0` and `v0.2.1`](https://github.com/RIOT-OS/riotctrl/pull/14), we need to use at least `v0.2.2`.