### PR TITLE
.travis.yml: bump RIOT version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 env:
-  - RIOT_BRANCH=2020.10-branch
+  - RIOT_BRANCH=2021.01-branch
 
 script:
   - docker build -t riot/riotdocker-base riotdocker-base


### PR DESCRIPTION
This bumps the RIOT release version used in Travis. This is required by #107 