### PR TITLE
riotbuild: bump version of pexpect and riotctrl

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -1,7 +1,7 @@
 # Required python libraries
 pyasn1==0.4.2
 ecdsa==0.13.3
-pexpect==4.2.1
+pexpect==4.8.0
 pycrypto==2.6.1
 pyserial==3.4
 ed25519==1.4
@@ -15,5 +15,5 @@ scikit-learn==0.22.1
 joblib==0.14.0
 emlearn==0.10.1
 jinja2==2.11.2
-riotctrl[rapidjson]>=0.2.2
+riotctrl[rapidjson]>=0.4.0
 pyhsslms>=1.0.0


### PR DESCRIPTION
I don't know how the riot container even can build (probably because the dependency fix was introduced after v0.2.2 of `riotctrl`), but `riotctrl` requires at least `pexpect` 4.7. So this bumps both `pexpect` and `riotctrl` to the most current version.