### PR TITLE
.github: add workflow to build and test images, usin `docker-container` driver

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,129 @@
+---
+name: build-test-pull-request
+
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  build-riotdocker-base:
+    name: Build and test pull request
+    runs-on: ubuntu-latest
+    env:
+      RIOT_BRANCH: 2020.10-branch
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache riotdocker-base layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-base
+          key: ${{ runner.os }}-buildx-base-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-base-
+
+      - name: Build and push riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          cache-from: type=local,src=/tmp/.buildx-cache-base
+          cache-to: type=local,dest=/tmp/.buildx-cache-base-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+
+      - name: Cache static-test-tools
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-static
+          key: ${{ runner.os }}-buildx-static-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-static-
+
+      - name: Build and push static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          build-args: |
+            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-static
+          cache-to: type=local,dest=/tmp/.buildx-cache-static-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-static
+          mv /tmp/.buildx-cache-static-new /tmp/.buildx-cache-static
+
+      - name: Cache riotbuild
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild
+          key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-
+
+      - name: Build and push riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          build-args: |
+            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild
+          mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild
+
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          repository: RIOT-OS/RIOT
+          ref: ${{ env.RIOT_BRANCH }}
+          path: RIOT
+
+      - name: Run gnu build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"
+
+      - name: Run llvm build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          TOOLCHAIN: llvm
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          BOARDS: "native samr21-xpro"
+
+      - name: Run static tests
+        run: |
+          docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest \
+          ./dist/tools/ci/static_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - '*'
 jobs:
-  build-riotdocker-base:
+  build-test:
     name: Build and test pull request
     runs-on: ubuntu-latest
     env:
@@ -61,9 +61,10 @@ jobs:
           context: ./static-test-tools
           platforms: linux/amd64
           load: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          pull: false
+          tags: test/static-test-tools:latest
           build-args: |
-            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_REGISTRY=test
           cache-from: type=local,src=/tmp/.buildx-cache-static
           cache-to: type=local,dest=/tmp/.buildx-cache-static-new
 
@@ -88,9 +89,10 @@ jobs:
           context: ./riotbuild
           platforms: linux/amd64
           load: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          pull: false
+          tags: test/riotbuild:latest
           build-args: |
-            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_REGISTRY=test
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
           cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
 
@@ -114,7 +116,7 @@ jobs:
           make -CRIOT/examples/hello-world buildtest
         env:
           BUILD_IN_DOCKER: 1
-          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          DOCKER_IMAGE: test/riotbuild:latest
           BOARDS: "arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"
 
       - name: Run llvm build test
@@ -123,11 +125,11 @@ jobs:
         env:
           TOOLCHAIN: llvm
           BUILD_IN_DOCKER: 1
-          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          DOCKER_IMAGE: test/riotbuild:latest
           BOARDS: "native samr21-xpro"
 
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
-          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch test/riotbuild:latest \
           ./dist/tools/ci/static_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -88,7 +88,7 @@ jobs:
           context: ./riotbuild
           platforms: linux/amd64
           load: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:test
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
           build-args: |
             DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,11 +10,18 @@ on:
     branches:
       - '*'
 jobs:
-  build-test:
-    name: Build and test pull request
+  build:
+    name: Build pull request
     runs-on: ubuntu-latest
-    env:
-      RIOT_BRANCH: '2020.10'
+    # buildx uses `docker-container` deriver by default which allows
+    # exporting cache and multi-platform builds, but it does not support
+    # accessing local images so a registry is required, so setup a local
+    # one
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     steps:
       - name: checkout
@@ -22,6 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
 
       - name: Cache riotdocker-base layer
         uses: actions/cache@v2
@@ -34,9 +43,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./riotdocker-base
-          platforms: linux/amd64
-          load: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          push: true
+          tags: localhost:5000/riotdocker-base:latest
           cache-from: type=local,src=/tmp/.buildx-cache-base
           cache-to: type=local,dest=/tmp/.buildx-cache-base-new
 
@@ -59,12 +67,10 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./static-test-tools
-          platforms: linux/amd64
-          load: true
-          pull: false
-          tags: test/static-test-tools:latest
+          push: true
+          tags: localhost:5000/static-test-tools:latest
           build-args: |
-            DOCKERHUB_REGISTRY=test
+            DOCKERHUB_REGISTRY=localhost:5000
           cache-from: type=local,src=/tmp/.buildx-cache-static
           cache-to: type=local,dest=/tmp/.buildx-cache-static-new
 
@@ -87,14 +93,18 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./riotbuild
-          platforms: linux/amd64
-          load: true
-          pull: false
-          tags: test/riotbuild:latest
+          tags: localhost:5000/riotbuild:latest
           build-args: |
-            DOCKERHUB_REGISTRY=test
+            DOCKERHUB_REGISTRY=localhost:5000
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
           cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+          outputs: type=docker,dest=/tmp/riotbuild.tar
+
+      - name: Upload riotbuild image
+        uses: actions/upload-artifact@v2
+        with:
+          name: riotbuild
+          path: /tmp/riotbuild.tar
 
       - name: Move cache
         # Temp fix
@@ -104,6 +114,13 @@ jobs:
           rm -rf /tmp/.buildx-cache-riotbuild
           mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild
 
+  test-gnu:
+    name: GNU build test
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      RIOT_BRANCH: '2020.10'
+    steps:
       - name: Checkout RIOT
         uses: actions/checkout@v2
         with:
@@ -111,25 +128,84 @@ jobs:
           ref: ${{ env.RIOT_BRANCH }}-branch
           path: RIOT
 
-      - name: Run gnu build test
+      - name: Download riotbuild.tar
+        uses: actions/download-artifact@v2
+        with:
+          name: riotbuild
+          path: /tmp
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: buildtest
         run: |
+          docker load --input /tmp/riotbuild.tar
           make -CRIOT/examples/hello-world buildtest
         env:
           BUILD_IN_DOCKER: 1
-          DOCKER_IMAGE: test/riotbuild:latest
+          DOCKER_IMAGE: localhost:5000/riotbuild:latest
           BOARDS: "arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"
 
-      - name: Run llvm build test
+
+  test-llvm:
+    name: LLVM build test
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      RIOT_BRANCH: '2020.10'
+    steps:
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          repository: RIOT-OS/RIOT
+          ref: ${{ env.RIOT_BRANCH }}-branch
+          path: RIOT
+
+      - name: Download riotbuild.tar
+        uses: actions/download-artifact@v2
+        with:
+          name: riotbuild
+          path: /tmp
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: buildtest
         run: |
+          docker load --input /tmp/riotbuild.tar
           make -CRIOT/examples/hello-world buildtest
         env:
           TOOLCHAIN: llvm
           BUILD_IN_DOCKER: 1
-          DOCKER_IMAGE: test/riotbuild:latest
+          DOCKER_IMAGE: localhost:5000/riotbuild:latest
           BOARDS: "native samr21-xpro"
+
+  static-test:
+    name: Static Tests
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      RIOT_BRANCH: '2020.10'
+    steps:
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          repository: RIOT-OS/RIOT
+          ref: ${{ env.RIOT_BRANCH }}-branch
+          path: RIOT
+
+      - name: Download riotbuild.tar
+        uses: actions/download-artifact@v2
+        with:
+          name: riotbuild
+          path: /tmp
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Run static tests
         run: |
+          docker load --input /tmp/riotbuild.tar
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
-          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch test/riotbuild:latest \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch localhost:5000/riotbuild:latest \
           ./dist/tools/ci/static_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and test pull request
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: 2020.10-branch
+      RIOT_BRANCH: '2020.10'
 
     steps:
       - name: checkout
@@ -102,7 +102,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: RIOT-OS/RIOT
-          ref: ${{ env.RIOT_BRANCH }}
+          ref: ${{ env.RIOT_BRANCH }}-branch
           path: RIOT
 
       - name: Run gnu build test
@@ -125,5 +125,5 @@ jobs:
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
-          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest \
           ./dist/tools/ci/static_tests.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,6 +2,10 @@
 name: build-test-pull-request
 
 on:
+  push:
+    branches:
+      - trying
+      - staging
   pull_request:
     branches:
       - '*'
@@ -51,7 +55,7 @@ jobs:
           key: ${{ runner.os }}-buildx-static-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-static-
 
-      - name: Build and push static-test-tools
+      - name: Build static-test-tools
         uses: docker/build-push-action@v2
         with:
           context: ./static-test-tools
@@ -59,7 +63,7 @@ jobs:
           load: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
           build-args: |
-            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
           cache-from: type=local,src=/tmp/.buildx-cache-static
           cache-to: type=local,dest=/tmp/.buildx-cache-static-new
 
@@ -78,15 +82,15 @@ jobs:
           key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-riotbuild-
 
-      - name: Build and push riotbuild
+      - name: Build riotbuild
         uses: docker/build-push-action@v2
         with:
           context: ./riotbuild
           platforms: linux/amd64
           load: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:test
           build-args: |
-            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
           cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,109 @@
+---
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-riotdocker-base:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    env:
+      RIOT_BRANCH: 2020.10-branch
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache riotdocker-base layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-base
+          key: ${{ runner.os }}-buildx-base-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-base-
+
+      - name: Build and push riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          cache-from: type=local,src=/tmp/.buildx-cache-base
+          cache-to: type=local,dest=/tmp/.buildx-cache-base-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+
+      - name: Cache static-test-tools
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-static
+          key: ${{ runner.os }}-buildx-static-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-static-
+
+      - name: Build and push static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-static
+          cache-to: type=local,dest=/tmp/.buildx-cache-static-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-static
+          mv /tmp/.buildx-cache-static-new /tmp/.buildx-cache-static
+
+      - name: Cache riotbuild
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild
+          key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-
+
+      - name: Build and push riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild
+          mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and push images
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: 2020.10-branch
+      RIOT_BRANCH: '2021.01'
 
     steps:
       - name: checkout
@@ -40,7 +40,9 @@ jobs:
           platforms: linux/amd64
           pull: true
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:${{ env.RIOT_BRANCH }}
           cache-from: type=local,src=/tmp/.buildx-cache-base
           cache-to: type=local,dest=/tmp/.buildx-cache-base-new
 
@@ -66,7 +68,9 @@ jobs:
           platforms: linux/amd64
           pull: true
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:${{ env.RIOT_BRANCH }}
           build-args: |
             DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
           cache-from: type=local,src=/tmp/.buildx-cache-static
@@ -94,7 +98,9 @@ jobs:
           platforms: linux/amd64
           pull: true
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:${{ env.RIOT_BRANCH }}
           build-args: |
             DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  build-riotdocker-base:
+  build:
     name: Build and push images
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,12 @@ jobs:
           key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
           restore-keys: ${{ runner.os }}-buildx-riotbuild-
 
+      - name: set environment variables
+        run: |
+          echo "RIOTBUILD_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+          echo "RIOTBUILD_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "RIOTBUILD_VERSION=$(git describe --always)" >> $GITHUB_ENV
+
       - name: Build and push riotbuild
         uses: docker/build-push-action@v2
         with:
@@ -103,6 +109,9 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:${{ env.RIOT_BRANCH }}
           build-args: |
             DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+            RIOTBUILD_BRANCH=${{ env.RIOTBUILD_BRANCH }}
+            RIOTBUILD_COMMIT=${{ env.RIOTBUILD_COMMIT }}
+            RIOTBUILD_VERSION=${{ env.RIOTBUILD_VERSION }}
           cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
           cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
 

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -11,7 +11,7 @@
 # Use prebuilt image:
 # 1. Prebuilt image can be pulled from Docker Hub registry with:
 #      # docker pull riot/riotbuild
-# 
+#
 # Use own build image:
 # 1. Build own image based on latest base OS image (from the riotbuild directory):
 #      # docker build --pull -t riotbuild .
@@ -19,8 +19,8 @@
 # Usage:
 # 1. cd to riot root
 # 2. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
-
-FROM riot/static-test-tools:latest
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/static-test-tools:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -1,4 +1,5 @@
-FROM riot/riotdocker-base:latest
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base:latest
 
 LABEL maintainer="alexandre.abadie@inria.fr"
 


### PR DESCRIPTION
This PR adds a .github action workflow to build docker images using buildx (buildkit). There are two cases:

- pull-request build
  - builds and push to a local registry
  - runs tests for images in local registry
- master build (or merged pull-request)
  - builds and push to dockerhub
  - runstest on dockerhub

I enabled cache for the different docker images. I had to use a different cache for each image otherwise it did not work properly. Currently, the cache never gets cleaned out so I have to update the cache on every build otherwise when it gets filled up it starts being less effective and eventually halts the worker. The cache can also be run against a local registry, cons of this are that it can't be shared among jobs, or workflows.

I've played around with this for a bit and found some advantages and disadvantages:

pros:
  - easy to leverage buildkit
  - with buildkit we could do multiarch builds
  - can use github cache to speed up builds: with cache https://github.com/fjmolinas/riotdocker/actions/runs/580652072 14min, without https://github.com/fjmolinas/riotdocker/actions/runs/579022954 ~30 min.
  - anyone can see the status of the build not only people with access to dockerhub

cons:
 - jobs can't share a registry so if we start splitting in jobs we will need to use tarballs(when not wanting to push) and that is apparently [less efficient](https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei)
 - Splitting test into a separate job would require exporting to a tarball or similar.
 - can't split into workflow since currently having workflow depend on each other sucks (can only wait for completion not if it was successful)

Action trigger could also be against files, don't need to rebuild the base images if the only riotbuild changed for example. Although if there is a cache hit the lower images build take ~10s.