### PR TITLE
bors: add dockercloud stages to required CI results

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,1 @@
-status = ["continuous-integration/travis-ci/push"]
+status = ["continuous-integration/travis-ci/push", "ci/dockercloud-stage (/riotbuild)", "ci/dockercloud-stage (/riotdocker-base)", "ci/dockercloud-stage (/static-test-tools)"]


### PR DESCRIPTION
With #117 merged, bors now waits for travis to build a branch before merging.
As docker-hub is also building the other images (riotbuild-base and static-test-tools), this PR adds those stati to what bors is waiting for.