### PR TITLE
poc/multiarch: proof of concept for multiarch builds, addind flashers and individual toolchain images

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,129 @@
+---
+name: build-test-pull-request
+
+on:
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  build-riotdocker-base:
+    name: Build and test pull request
+    runs-on: ubuntu-latest
+    env:
+      RIOT_BRANCH: 2020.10-branch
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache riotdocker-base layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-base
+          key: ${{ runner.os }}-buildx-base-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-base-
+
+      - name: Build and push riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          cache-from: type=local,src=/tmp/.buildx-cache-base
+          cache-to: type=local,dest=/tmp/.buildx-cache-base-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+
+      - name: Cache static-test-tools
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-static
+          key: ${{ runner.os }}-buildx-static-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-static-
+
+      - name: Build and push static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          build-args: |
+            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-static
+          cache-to: type=local,dest=/tmp/.buildx-cache-static-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-static
+          mv /tmp/.buildx-cache-static-new /tmp/.buildx-cache-static
+
+      - name: Cache riotbuild
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild
+          key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-
+
+      - name: Build and push riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          platforms: linux/amd64
+          load: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          build-args: |
+            DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild
+          mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild
+
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          repository: RIOT-OS/RIOT
+          ref: ${{ env.RIOT_BRANCH }}
+          path: RIOT
+
+      - name: Run gnu build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1 msb-430h native pic32-wifire samr21-xpro"
+
+      - name: Run llvm build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          TOOLCHAIN: llvm
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          BOARDS: "native samr21-xpro"
+
+      - name: Run static tests
+        run: |
+          docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest \
+          ./dist/tools/ci/static_tests.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,109 @@
+---
+name: build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-riotdocker-base:
+    name: Build and push images
+    runs-on: ubuntu-latest
+    env:
+      RIOT_BRANCH: 2020.10-branch
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache riotdocker-base layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-base
+          key: ${{ runner.os }}-buildx-base-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-base-
+
+      - name: Build and push riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotdocker-base:latest
+          cache-from: type=local,src=/tmp/.buildx-cache-base
+          cache-to: type=local,dest=/tmp/.buildx-cache-base-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+
+      - name: Cache static-test-tools
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-static
+          key: ${{ runner.os }}-buildx-static-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-static-
+
+      - name: Build and push static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/static-test-tools:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-static
+          cache-to: type=local,dest=/tmp/.buildx-cache-static-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-static
+          mv /tmp/.buildx-cache-static-new /tmp/.buildx-cache-static
+
+      - name: Cache riotbuild
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild
+          key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-
+
+      - name: Build and push riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riotbuild:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_USERNAME }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild
+          mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild

--- a/.github/workflows/multiarch-poc.yml
+++ b/.github/workflows/multiarch-poc.yml
@@ -1,0 +1,381 @@
+---
+name: multiarch-poc
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  build-riotdocker-base:
+    name: Build and push images
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache riotdocker-base layer
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-base
+          key: ${{ runner.os }}-buildx-base-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-base-
+
+      - name: Build and push riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          file: ./riotdocker-base/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_REGISTRY }}/riotdocker-base:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+          cache-from: type=local,src=/tmp/.buildx-cache-base
+          cache-to: type=local,dest=/tmp/.buildx-cache-base-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-base
+          mv /tmp/.buildx-cache-base-new /tmp/.buildx-cache-base
+
+  build-static-test-tools:
+    needs: build-riotdocker-base
+    name: Build and push static-test-tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache static-test-tools
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-static
+          key: ${{ runner.os }}-buildx-static-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-static-
+
+      - name: Build and push static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          file: ./static-test-tools/Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_REGISTRY }}/static-test-tools:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+          cache-from: type=local,src=/tmp/.buildx-cache-static
+          cache-to: type=local,dest=/tmp/.buildx-cache-static-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-static
+          mv /tmp/.buildx-cache-static-new /tmp/.buildx-cache-static
+
+  build-riotbuild-essentials:
+    needs: build-static-test-tools
+    name: Build and push riotbuild-essentials
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache riotbuild-essentials
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild-essentials
+          key: ${{ runner.os }}-buildx-riotbuild-essentials-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-essentials-
+
+      - name: Build and push riotbuild-essentials
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild-essentials
+          file: ./riotbuild-essentials/Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_REGISTRY }}/riotbuild-essentials:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild-essentials
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-essentials-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild-essentials
+          mv /tmp/.buildx-cache-riotbuild-essentials-new /tmp/.buildx-cache-riotbuild-essentials
+
+  build-toolchains-base:
+    needs: build-riotdocker-base
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [gcc-arm-none-eabi.lite]
+    name: Build and push ${{ matrix.toolchain }}
+    env:
+      ARM_VERSION: gcc-arm-none-eabi-9-2019-q4-major
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache ${{ matrix.toolchain }}
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-${{ matrix.toolchain }}
+          key: ${{ runner.os }}-buildx-${{ matrix.toolchain }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-${{ matrix.toolchain }}-
+
+      - name: Build and push ${{ matrix.toolchain }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./toolchains/${{ matrix.toolchain }}.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ secrets.DOCKERHUB_REGISTRY }}/${{ matrix.toolchain }}:latest
+            ${{ secrets.DOCKERHUB_REGISTRY }}/${{ matrix.toolchain }}:${{ env.ARM_VERSION }}
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+            ARM_VERSION=${{ env.ARM_VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.toolchain }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.toolchain }}-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-${{ matrix.toolchain }}
+          mv /tmp/.buildx-cache-${{ matrix.toolchain }}-new /tmp/.buildx-cache-${{ matrix.toolchain }}
+
+
+  build-toolchains:
+    needs:
+      - build-riotbuild-essentials
+      - build-toolchains-base
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [gcc-arm-none-eabi]
+    name: Build and push ${{ matrix.toolchain }}
+    env:
+      ARM_VERSION: gcc-arm-none-eabi-9-2019-q4-major
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache ${{ matrix.toolchain }}
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-${{ matrix.toolchain }}
+          key: ${{ runner.os }}-buildx-${{ matrix.toolchain }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-${{ matrix.toolchain }}-
+
+      - name: Build and push ${{ matrix.toolchain }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./toolchains/${{ matrix.toolchain }}.Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ secrets.DOCKERHUB_REGISTRY }}/${{ matrix.toolchain }}:latest
+            ${{ secrets.DOCKERHUB_REGISTRY }}/${{ matrix.toolchain }}:${{ env.ARM_VERSION }}
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+            ARM_VERSION=${{ env.ARM_VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.toolchain }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.toolchain }}-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-${{ matrix.toolchain }}
+          mv /tmp/.buildx-cache-${{ matrix.toolchain }}-new /tmp/.buildx-cache-${{ matrix.toolchain }}
+
+  build-riotbuild:
+    needs:
+      - build-static-test-tools
+      - build-toolchains
+    name: Build and push riotbuild
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache riotbuild
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-riotbuild
+          key: ${{ runner.os }}-buildx-riotbuild-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-riotbuild-
+
+      - name: Build and push riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          file: ./riotbuild/Dockerfile
+          platforms: linux/amd64
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_REGISTRY }}/riotbuild:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+          cache-from: type=local,src=/tmp/.buildx-cache-riotbuild
+          cache-to: type=local,dest=/tmp/.buildx-cache-riotbuild-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-riotbuild
+          mv /tmp/.buildx-cache-riotbuild-new /tmp/.buildx-cache-riotbuild
+
+  build-flashers:
+    needs: build-riotdocker-base
+    strategy:
+      fail-fast: false
+      matrix:
+        flasher: [jlink, edbg, openocd]
+    name: Build and push ${{ matrix.flasher }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache ${{ matrix.flasher }}
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-${{ matrix.flasher }}
+          key: ${{ runner.os }}-buildx-${{ matrix.flasher }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-${{ matrix.flasher }}-
+
+      - name: Build and push ${{ matrix.flasher }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./flashers/${{ matrix.flasher }}.Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          pull: true
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ secrets.DOCKERHUB_REGISTRY }}/${{ matrix.flasher }}:latest
+          build-args: |
+            DOCKERHUB_REGISTRY=${{ secrets.DOCKERHUB_REGISTRY }}
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.flasher }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.flasher }}-new
+
+      - name: Move cache
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        run: |
+          rm -rf /tmp/.buildx-cache-${{ matrix.flasher }}
+          mv /tmp/.buildx-cache-${{ matrix.flasher }}-new /tmp/.buildx-cache-${{ matrix.flasher }}

--- a/flashers/edbg.Dockerfile
+++ b/flashers/edbg.Dockerfile
@@ -1,0 +1,46 @@
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ubuntu:bionic AS builder
+
+ARG EDBG_INSTALL_DEPS="git ca-certificates build-essential libudev-dev"
+ARG EDBG_VERSION=47c6ba4f7e61b0cce1b724cb62692de6e26a0267
+
+# Upgrading system packages to the latest available versions
+RUN apt-get update && apt-get -y dist-upgrade
+# Installing required packages for flashing toolchain
+RUN apt-get -y --no-install-recommends install \
+        ${EDBG_INSTALL_DEPS} \
+    # Cleaning up installation files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Compile edbg binary
+RUN mkdir -p opt \
+    && cd /opt \
+    && git clone --depth 1 https://github.com/ataradov/edbg \
+    && cd edbg \
+    && git checkout -q ${EDBG_VERSION} \
+    && make -j"$(nproc)" \
+    && make all
+
+ARG DOCKERHUB_REGISTRY
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base
+
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+ARG FLASH_DEPS="make unzip wget"
+
+ARG EDBG_DEPS=""
+
+# Upgrading system packages to the latest available versions
+RUN apt-get update && apt-get -y dist-upgrade
+# Installing required packages for flashing toolchain
+RUN apt-get -y --no-install-recommends install \
+        ${EDBG_DEPS} \
+        ${FLASH_DEPS} \
+    # Cleaning up installation files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy edbg binary from previous stage
+COPY --from=builder /opt/edbg/edbg /usr/local/bin/edbg
+
+# Set default EDBG in the environment
+ENV EDBG=/usr/local/bin/edbg

--- a/flashers/jlink.Dockerfile
+++ b/flashers/jlink.Dockerfile
@@ -1,0 +1,37 @@
+ARG TARGETPLATFORM
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base
+
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+ARG FLASH_DEPS="make unzip"
+ARG EDBG_INSTALL_DEPS="wget ca-certificates"
+
+ARG JLINK_VERSION=694d
+ARG JLINK_DEPS=""
+
+# Upgrading system packages to the latest available versions
+RUN apt-get update && apt-get -y dist-upgrade
+# Installing required packages for flashing toolchain
+RUN apt-get -y --no-install-recommends install \
+        ${JLINK_DEPS} \
+        ${EDBG_INSTALL_DEPS} \
+        ${FLASH_DEPS} \
+    # Cleaning up installation files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Jlink
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM=${TARGETPLATFORM:-linux/amd64}
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] ; \
+        then export ARCH="x86_64"; \
+    elif [ "${TARGETPLATFORM}" = "linux/arm64" ] ; \
+        then export ARCH="arm64"; \
+    elif [ "${TARGETPLATFORM}" = "linux/arm/v7" ] ; \
+        then export ARCH="arm"; \
+    fi \
+    && echo $ARCH \
+    && wget --no-check-certificate --post-data 'accept_license_agreement=accepted&non_emb_ctr=confirmed&submit="Download software"'\
+    https://www.segger.com/downloads/jlink/JLink_Linux_V${JLINK_VERSION}_${ARCH}.deb \
+    && dpkg --install JLink_Linux_V${JLINK_VERSION}_${ARCH}.deb \
+    && rm JLink_Linux_V${JLINK_VERSION}_${ARCH}.deb

--- a/flashers/openocd.Dockerfile
+++ b/flashers/openocd.Dockerfile
@@ -1,0 +1,35 @@
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base
+
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+ARG FLASH_DEPS="make unzip wget"
+
+ARG OPENOCD_INSTALL_DEPS="build-essential git ca-certificates libtool pkg-config autoconf automake texinfo \
+                          libhidapi-hidraw0 libhidapi-dev libusb-1.0"
+ARG OPENOCD_VERSION=5f3bc3b279c648f5c751fcd4724206c6ce3e38c6
+ARG OPENOCD_DEPS=""
+
+# Upgrading system packages to the latest available versions
+RUN apt-get update && apt-get -y dist-upgrade
+# Installing required packages for flashing toolchain
+RUN apt-get -y --no-install-recommends install \
+        ${OPENOCD_INSTALL_DEPS} \
+        ${OPENOCD_DEPS} \
+        ${FLASH_DEPS} \
+    # Cleaning up installation files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Build openocd from source
+RUN mkdir -p opt \
+    && cd /opt \
+    && git clone --depth 1 git://git.code.sf.net/p/openocd/code openocd\
+    && cd openocd \
+    && git checkout -q ${OPENOCD_VERSION} \
+    && ./bootstrap \
+    && ./configure --enable-stlink --enable-jlink --enable-ftdi --enable-cmsis-dap \
+    && make -j"$(nproc)" \
+    && make install-strip \
+    && cd .. \
+    && rm -rf openocd \
+    && rm -rf /var/lib/apt/lists/*

--- a/riotbuild-essentials/Dockerfile
+++ b/riotbuild-essentials/Dockerfile
@@ -1,0 +1,39 @@
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/static-test-tools
+
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+RUN \
+    echo 'Update the package index files to latest available versions' >&2 && \
+    apt-get update && \
+    echo 'Installing riot-build-essentials' >&2 && \
+    apt-get -y --no-install-recommends install \
+        # required by RIOT build system
+        unzip \
+        curl \
+        # for building many packades
+        g++ \
+        # required for hexdump
+        bsdmainutils \
+         # required for xxd
+        vim-common \
+        cmake \
+        patch \
+        # To install python packages (next two)
+        python3-setuptools \
+        python3-wheel \
+        # For nanopb
+        protobuf-compiler \
+        # For picolibc
+        ninja-build \
+        && \
+    echo 'Cleaning up installation files' >&2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install required Python packages
+COPY requirements.txt /tmp/requirements.txt
+# numpy must be already installed before installing other requirements
+RUN pip3 install --no-cache-dir numpy==1.17.4
+RUN echo 'Installing python3 packages' >&2 && \
+    pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+    rm -f /tmp/requirements.txt

--- a/riotbuild-essentials/requirements.txt
+++ b/riotbuild-essentials/requirements.txt
@@ -1,0 +1,18 @@
+# Required python libraries
+## For SUIT
+cbor==1.0.0
+cbor2>=5.0.0
+colorama>=0.4.0
+cryptography==2.6.1
+ed25519==1.4
+pyhsslms>=1.0.0
+## For emlearn
+protobuf==3.10.0
+scikit-learn==0.22.1
+emlearn==0.10.1
+joblib==0.14.0
+## Multiple packages
+pyasn1==0.4.2
+ecdsa==0.13.3
+## For kconfig
+jinja2

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -20,7 +20,8 @@
 # 1. cd to riot root
 # 2. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
 ARG DOCKERHUB_REGISTRY="riot"
-FROM ${DOCKERHUB_REGISTRY}/static-test-tools:latest
+FROM ${DOCKERHUB_REGISTRY}/gcc-arm-none-eabi as gcc-arm-none-eabi
+FROM ${DOCKERHUB_REGISTRY}/riotbuild-essentials:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 
@@ -107,21 +108,10 @@ RUN \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install ARM GNU embedded toolchain
-# For updates, see https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
-ARG ARM_URLBASE=https://developer.arm.com/-/media/Files/downloads/gnu-rm
-ARG ARM_URL=${ARM_URLBASE}/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
-ARG ARM_MD5=fe0029de4f4ec43cf7008944e34ff8cc
-ARG ARM_FOLDER=gcc-arm-none-eabi-9-2019-q4-major
-RUN echo 'Installing arm-none-eabi toolchain from arm.com' >&2 && \
-    mkdir -p /opt && \
-    curl -L -o /opt/gcc-arm-none-eabi.tar.bz2 ${ARM_URL} && \
-    echo "${ARM_MD5} /opt/gcc-arm-none-eabi.tar.bz2" | md5sum -c && \
-    tar -C /opt -jxf /opt/gcc-arm-none-eabi.tar.bz2 && \
-    rm -f /opt/gcc-arm-none-eabi.tar.bz2 && \
-    echo 'Removing documentation' >&2 && \
-    rm -rf /opt/gcc-arm-none-eabi-*/share/doc
-    # No need to dedup, the ARM toolchain is already using hard links for the duplicated files
-
+ARG ARM_FOLDER=gcc-arm-none-eabi
+RUN mkdir -p /opt/${ARM_FOLDER}
+COPY --from=gcc-arm-none-eabi /opt/${ARM_FOLDER} /opt/${ARM_FOLDER}
+# Add to PATH
 ENV PATH ${PATH}:/opt/${ARM_FOLDER}/bin
 
 # Install MIPS binary toolchain

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -11,7 +11,7 @@
 # Use prebuilt image:
 # 1. Prebuilt image can be pulled from Docker Hub registry with:
 #      # docker pull riot/riotbuild
-# 
+#
 # Use own build image:
 # 1. Build own image based on latest base OS image (from the riotbuild directory):
 #      # docker build --pull -t riotbuild .
@@ -19,8 +19,8 @@
 # Usage:
 # 1. cd to riot root
 # 2. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
-
-FROM riot/static-test-tools:latest
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/static-test-tools:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 

--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -1,19 +1,7 @@
 # Required python libraries
-pyasn1==0.4.2
-ecdsa==0.13.3
-pexpect==4.8.0
+pexpect==4.2.1
 pycrypto==2.6.1
 pyserial==3.4
-ed25519==1.4
-cbor==1.0.0
-cbor2>=5.0.0
-colorama>=0.4.0
-cryptography==3.2
 scapy>=2.4.3
-protobuf==3.10.0
-scikit-learn==0.22.1
-joblib==0.14.0
-emlearn==0.10.1
-jinja2==2.11.2
-riotctrl[rapidjson]>=0.4.0
+riotctrl>=0.1.1
 pyhsslms>=1.0.0

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -1,4 +1,5 @@
-FROM riot/riotdocker-base:latest
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base:latest
 
 LABEL maintainer="alexandre.abadie@inria.fr"
 

--- a/toolchains/gcc-arm-none-eabi.Dockerfile
+++ b/toolchains/gcc-arm-none-eabi.Dockerfile
@@ -1,0 +1,12 @@
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/gcc-arm-none-eabi.lite as gcc-arm-none-eabi
+FROM ${DOCKERHUB_REGISTRY}/riotbuild-essentials
+
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+# Install ARM GNU embedded toolchain
+ARG ARM_FOLDER=gcc-arm-none-eabi
+RUN mkdir -p /opt/${ARM_FOLDER}
+COPY --from=gcc-arm-none-eabi /opt/${ARM_FOLDER} /opt/${ARM_FOLDER}
+# Add to PATH
+ENV PATH ${PATH}:/opt/${ARM_FOLDER}/bin

--- a/toolchains/gcc-arm-none-eabi.lite.Dockerfile
+++ b/toolchains/gcc-arm-none-eabi.lite.Dockerfile
@@ -1,0 +1,19 @@
+ARG DOCKERHUB_REGISTRY="riot"
+FROM ${DOCKERHUB_REGISTRY}/riotdocker-base
+LABEL maintainer="francois-xavier.molina@inria.fr"
+
+# Dependencies to install gcc-arm-none-eabi
+ARG ARM_INSTALL_DEPS="curl bzip2"
+# Dependencies to compile gcc-arm-none-eabi
+ARG ARM_BUILD_DEPS="make unzip"
+
+# Upgrading system packages to the latest available versions
+RUN apt-get update && apt-get -y dist-upgrade
+# Installing required packages for flashing toolchain
+RUN apt-get -y --no-install-recommends install \
+        ${ARM_INSTALL_DEPS} \
+        ${ARM_BUILD_DEPS} \
+    # Cleaning up installation files
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV PATH ${PATH}:/opt/gcc-arm-none-eabi/bin


### PR DESCRIPTION
As discussed recently this PR wants to show some things that we could do and leverage with build:

- multi arch builds: `flashers` are built for `arm64` `amd64` and `armv7`. Toolchains are not built for all, ran into some issues and since this is a POC just went for those that were easy to handle.

- flasher images: I use https://github.com/RIOT-OS/RIOT/pull/12419 so commands of the type `docker/flash-only` since these images are meant to be light weight so do not contain compilation tools or toolchains. ~500Mb for openocd, definitely room for improvement for starters not using ubuntu as the base image, using multistage builds etc...

- individual toolchain images: easier to version and lighter `arm-none-eabi-gcc` lite image (won't be able to compile everything in RIOT) is ~700Mb and with all requirements to build ~1.4Gb. We can imagine versioning them according to the toolchain version as well as the current release. 

- leverage multistage builds: in this case, it is done only for  `arm-none-eabi-gcc` where only the binaries are copied.

In this PR I added another base image `riotbuild-essentials` that want to gather all common build tools. A successful workflow can be seen at https://github.com/fjmolinas/riotdocker/actions/runs/622288134, once cache is hot the whole workflow is pretty fast ~10min, less for individual stages. Some of them could be decoupled, even split into workflows but currently, Github actions tools for workflow dependencies is pretty new and has quite heavy limitations, I would rather wait for it to mature before going there.

Lastly, I'm currently hosting these images in my own registry if you want to try them out. I also have a simplified rebased version of  https://github.com/RIOT-OS/RIOT/pull/12419 in https://github.com/fjmolinas/RIOT/tree/dev/docker_targets which I'm mostly using ATM to flash on rpi3 with docker support over ssh. There a little more going into this but its also easy to setup.

So feedback wanted, is this worth pursuing? As you can see from the test workflow all the flashers part is quite independent and can be split out completely, in the past I had many more images https://github.com/fjmolinas/riotdocker/tree/flashtools_dockerfiles/flashers but I haven't tested them all and it was a while ago, but as you can see its pretty simple and easy to setup.

Splitting out the toolchains is a bit more of work (I for example had issues with picolibc and did not tackle that for now).

If this is worth pursuing IMO the first step is adding github actions workflows like #136, the flashers can be added, then some more base images like the `riotbuild-essentials` one and a `riotbuild-test` or something like that. Then toolchains can be decoupled if wanted.