### PR TITLE
replace uncrustify with binary

### DIFF
--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -20,7 +20,6 @@ RUN \
         make \
         pcregrep \
         shellcheck \
-        uncrustify \
         vera++ \
         wget \
         && \
@@ -32,3 +31,10 @@ COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 && \
     pip3 install --no-cache-dir -r /tmp/requirements.txt && \
     rm -f /tmp/requirements.txt
+
+ARG UNCRUSTIFY_URL=https://github.com/kaspar030/uncrustify-builder/releases/download/0.72.0/uncrustify-0.72.0.gz
+ARG UNCRUSTIFY_BIN=/usr/local/bin/uncrustify
+RUN echo 'Installing uncrustify binary' >&2 && \
+    wget $UNCRUSTIFY_URL -O ${UNCRUSTIFY_BIN}.gz && \
+    gunzip ${UNCRUSTIFY_BIN}.gz && \
+    chmod 0755 ${UNCRUSTIFY_BIN}


### PR DESCRIPTION
Ubuntu's uncrustify is outdated, even in newer Ubuntu releases.

This PR sets up getting uncrustify from https://github.com/kaspar030/uncrustify-builder.