### PR TITLE
.github: add workflow to build and test images, using `docker` driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,131 @@
+---
+# This workflow will run on all pull-request branches and on 'master',
+# 'staging', and 'trying'
+#
+# In all cases it will incrementally build: riotdocker-base, static-test-tools
+# and riotbuild
+#
+# If riotbuild is successfully built then it will run a simple compile test on
+# a subset of BOARDs using gcc and llvm
+#
+# On master if the building and testing succeeds it will push the generated image
+# to ${DOCKER_REGISTRY}
+#
+# * Requirements:
+#   * Add the following secrets:
+#     * DOCKER_REGISTRY: the registry to pull and push images from/to
+#     * DOCKERHUB_USERNAME: the Docker Hub username account that can
+#       publish to ${DOCKER_REGISTRY}
+#     * DOCKERHUB_PASSWORD: the Docker Hub password for ${DOCKERHUB_USERNAME}
+#
+name: build
+
+on:
+  push:
+    branches:
+      - trying
+      - staging
+      - master
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  build-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    env:
+      RIOT_BRANCH: '2021.01'
+      DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
+
+      - name: Build riotdocker-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotdocker-base
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
+            ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.RIOT_BRANCH }}
+
+      - name: Build static-test-tools
+        uses: docker/build-push-action@v2
+        with:
+          context: ./static-test-tools
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/static-test-tools:latest
+            ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.RIOT_BRANCH }}
+          build-args: |
+            DOCKER_REGISTRY=local
+
+      - name: Set environment variables
+        run: |
+          echo "RIOTBUILD_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+          echo "RIOTBUILD_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "RIOTBUILD_VERSION=$(git describe --always)" >> $GITHUB_ENV
+
+      - name: Build riotbuild
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+            ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.RIOT_BRANCH }}
+          build-args: |
+            DOCKER_REGISTRY=local
+            RIOTBUILD_BRANCH=${{ env.RIOTBUILD_BRANCH }}
+            RIOTBUILD_COMMIT=${{ env.RIOTBUILD_COMMIT }}
+            RIOTBUILD_VERSION=${{ env.RIOTBUILD_VERSION }}
+
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+        with:
+          repository: RIOT-OS/RIOT
+          ref: ${{ env.RIOT_BRANCH }}-branch
+          path: RIOT
+
+      - name: GNU build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native pic32-wifire samr21-xpro"
+
+      - name: LLVM build test
+        run: |
+          make -CRIOT/examples/hello-world buildtest
+        env:
+          TOOLCHAIN: llvm
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          BOARDS: "native samr21-xpro"
+
+      - name: Run static tests
+        run: |
+          docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
+          ./dist/tools/ci/static_tests.sh
+
+      - name: Login to DockerHub
+        if: "${{ github.ref == 'refs/heads/master' }}"
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Images
+        if: "${{ github.ref == 'refs/heads/master' }}"
+        run: |
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.RIOT_BRANCH }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.RIOT_BRANCH }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.RIOT_BRANCH }}

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -11,7 +11,7 @@
 # Use prebuilt image:
 # 1. Prebuilt image can be pulled from Docker Hub registry with:
 #      # docker pull riot/riotbuild
-# 
+#
 # Use own build image:
 # 1. Build own image based on latest base OS image (from the riotbuild directory):
 #      # docker build --pull -t riotbuild .
@@ -19,8 +19,8 @@
 # Usage:
 # 1. cd to riot root
 # 2. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
-
-FROM riot/static-test-tools:latest
+ARG DOCKER_REGISTRY="riot"
+FROM ${DOCKER_REGISTRY}/static-test-tools:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -1,4 +1,5 @@
-FROM riot/riotdocker-base:latest
+ARG DOCKER_REGISTRY="riot"
+FROM ${DOCKER_REGISTRY}/riotdocker-base:latest
 
 LABEL maintainer="alexandre.abadie@inria.fr"
 


### PR DESCRIPTION
This PR is a simplified alternative to https://github.com/RIOT-OS/riotdocker/pull/136, the major difference comes from it using the `docker` driver instead of `docker-container` driver for buildx which basically makes it behave like regular docker, so: no-cache, no multiplatform build, but the workflow can be simplified a lot.

I personally think we lose a lot with this, but being able to replace Travis, Docker with only GitHub actions, integrate versioning is a huge plus and this PR should be easier to integrate and to understand (there are a lot of workarounds to be done with `docker-container` driver as seen in #136).