### PR TITLE
make travis fail on error exit of any step (`set -e`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - RIOT_BRANCH=2021.01-branch
 
 script:
+  - set -e
   - docker build -t riot/riotdocker-base riotdocker-base
   - docker build -t riot/static-test-tools static-test-tools
   - docker build --pull -t riotdocker riotbuild 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - RIOT_BRANCH=2021.01-branch
 
 script:
+  # make error in any step abort the script
   - set -e
   - docker build -t riot/riotdocker-base riotdocker-base
   - docker build -t riot/static-test-tools static-test-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ env:
   - RIOT_BRANCH=2021.01-branch
 
 script:
+  # log in to docker hub for bors builds
+  # (travis doesn't pass the necessary env vars to PR builds)
+  - echo "staging trying master" | grep -qw "$TRAVIS_BRANCH" && echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
+
   # make error in any step abort the script
   - set -e
-  # log in to docker hub
-  - echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
-
   - docker build -t riot/riotdocker-base riotdocker-base
   - docker build -t riot/static-test-tools static-test-tools
   - docker build --pull -t riotdocker riotbuild 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
 script:
   # make error in any step abort the script
   - set -e
+  # log in to docker hub
+  - echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USER" --password-stdin
+
   - docker build -t riot/riotdocker-base riotdocker-base
   - docker build -t riot/static-test-tools static-test-tools
   - docker build --pull -t riotdocker riotbuild 


### PR DESCRIPTION
Some builds continue even though an early step fails,
e.g., https://travis-ci.org/github/RIOT-OS/riotdocker/builds/773366924.

This does a `set -e`. let's see if this fixes the issue.