### PR TITLE
.github/workflows/build.yml: fix wrong secrets reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         if: "${{ github.ref == 'refs/heads/master' }}"
         uses: docker/login-action@v1
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push Images


### PR DESCRIPTION
Another issue that snuck in during the renaming... sorry for all the wasted ci time.