### PR TITLE
.github/workflows/build.yml: bump RIOT branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2021.01'
+      RIOT_BRANCH: '2021.04-branch'
+      VERSION_TAG: '2021.07'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:
@@ -52,7 +53,7 @@ jobs:
           context: ./riotdocker-base
           tags: |
             ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
-            ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.RIOT_BRANCH }}
+            ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.VERSION_TAG }}
 
       - name: Build static-test-tools
         uses: docker/build-push-action@v2
@@ -60,7 +61,7 @@ jobs:
           context: ./static-test-tools
           tags: |
             ${{ env.DOCKER_REGISTRY }}/static-test-tools:latest
-            ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.RIOT_BRANCH }}
+            ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.VERSION_TAG }}
           build-args: |
             DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
 
@@ -76,7 +77,7 @@ jobs:
           context: ./riotbuild
           tags: |
             ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-            ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.RIOT_BRANCH }}
+            ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.VERSION_TAG }}
           build-args: |
             DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
             RIOTBUILD_BRANCH=${{ env.RIOTBUILD_BRANCH }}
@@ -87,7 +88,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: RIOT-OS/RIOT
-          ref: ${{ env.RIOT_BRANCH }}-branch
+          ref: ${{ env.RIOT_BRANCH }}
           path: RIOT
 
       - name: GNU build test
@@ -110,7 +111,7 @@ jobs:
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
-          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }}-branch ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
           ./dist/tools/ci/static_tests.sh
 
       - name: Login to DockerHub
@@ -124,8 +125,8 @@ jobs:
         if: "${{ github.ref == 'refs/heads/master' }}"
         run: |
           docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
-          docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.RIOT_BRANCH }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.VERSION_TAG }}
           docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:latest
-          docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.RIOT_BRANCH }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:${{ env.VERSION_TAG }}
           docker image push ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-          docker image push ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.RIOT_BRANCH }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/riotbuild:${{ env.VERSION_TAG }}


### PR DESCRIPTION
I initially misunderstood how our branches were named, and though I could re-user the RIOT_BRANCH use for testing as the tag for the image, but IMO it makes more sense to tag the next release version. Instead, so how I see it would be:

- tag the DOCKER image with the next release version (so in current case `2021.07`) while building against `2021.04-branch`
- once release is over switch RIOT_BRANCH to `2021.07-branch` and `VERSION_TAG` to `2021.10`

Maybe it's a good time to discuss how to version our images as well.
