### PR TITLE
riotbuild: Install Rust (minimal edition)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ on:
   pull_request:
     branches:
       - '*'
+
 jobs:
   build-test:
     name: Build and Test

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -1,0 +1,11 @@
+FROM immunant/c2rust:ubuntu-bionic-latest as c2rust
+
+# --locked --git --branch ignores --locked; new (2021-03-something) cargo
+# versions behave properly, but C2Rust is on a 2019-12-05 toolchain.
+#
+# Cleaning up cargo home again as set by C2Rust image (that's what contributes
+# most to the delta between the immunant container and this one).
+RUN git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
+    cargo install --locked --root /usr --path c2rust/c2rust && \
+    rm -rf c2rust && \
+    rm -rf ${CARGO_HOME}

--- a/c2rust-built/README.md
+++ b/c2rust-built/README.md
@@ -1,0 +1,15 @@
+This image contains built and usable versions of [c2rust].
+It is provided because upstream [does not release binaries] for c2rust and its companion tools,
+and because the [branch this is built from (for-riot)] contains some fixes to c2rust required to work on RIOT.
+
+As this changes rarely,
+and because on the github-workers infrastructure this is [difficult to get right],
+this is not built and used through CI yet,
+but manually built an published as:
+
+    docker build . -t chrysn/c2rust-built
+
+[c2rust]: https://github.com/immunant/c2rust
+[does not release binaries]: https://github.com/immunant/c2rust/issues/326
+[branch this is built from (for-riot)]: https://github.com/chrysn-pull-requests/c2rust/tree/for-riot
+[difficult to get right]: https://github.com/RIOT-OS/riotdocker/pull/141

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -91,7 +91,11 @@ RUN \
         clang-tools-${LLVM_VERSION}/bionic-updates \
         llvm \
         clang \
-        clang-tools && \
+        clang-tools \
+    && echo 'Installing LLVM version needed by the C2Rust binaries' >&2 && \
+    apt-get -y --no-install-recommends install \
+        llvm-7-dev \
+        && \
     SYMS=$(find /usr/bin -type l) && \
     for file in ${SYMS}; do \
         SYMTARGET=$(readlink -f ${file}) && \
@@ -258,6 +262,31 @@ RUN echo 'Installing python3 packages' >&2 \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 
+# While sourcing ~/.cargo/env later would have the right short-term effect,
+# we'd still need to set the right path even later when HOME is
+# /data/riotbuild -- so setting it right away.
+ENV PATH ${PATH}:/opt/rustup/.cargo/bin
+# Install nightly Rust via rustup; this is needed for Rust-on-RIOT builds and
+# contains all CARGO_TARGETs currently recognized for RIOT targets.
+#
+# *_HOMEs moved to /opt to make them world readable. RUSTUP_HOME is set
+# persistently in case someone in their image wants to do a quick `sudo rustup
+# toolchain add` or similar; CARGO_HOME is not because the user will need to
+# write there, and all rustup does here is to place some binaries that later
+# fan out to RUSTUP_HOME anyway.
+ENV RUSTUP_HOME /opt/rustup/.rustup
+RUN \
+    RUSTUP_HOME=/opt/rustup/.rustup \
+    CARGO_HOME=/opt/rustup/.cargo sh -c "\
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2021-08-28 && \
+    rustup target add i686-unknown-linux-gnu && \
+    rustup target add riscv32imac-unknown-none-elf && \
+    rustup target add thumbv7em-none-eabihf && \
+    rustup target add thumbv7em-none-eabi && \
+    rustup target add thumbv7m-none-eabi && \
+    rustup target add thumbv6m-none-eabi && \
+    true"
+
 # get Dockerfile version from build args
 ARG RIOTBUILD_VERSION=unknown
 ENV RIOTBUILD_VERSION $RIOTBUILD_VERSION
@@ -272,3 +301,6 @@ ENV RIOTBUILD_BRANCH $RIOTBUILD_BRANCH
 RUN echo "RIOTBUILD_VERSION=$RIOTBUILD_VERSION" > /etc/riotbuild
 RUN echo "RIOTBUILD_COMMIT=$RIOTBUILD_COMMIT" >> /etc/riotbuild
 RUN echo "RIOTBUILD_BRANCH=$RIOTBUILD_BRANCH" >> /etc/riotbuild
+
+# These depend on llvm-7-dev to be installed
+COPY --from=chrysn/c2rust-built /usr/bin/c2rust /usr/bin/c2rust-refactor /usr/bin/c2rust-transpile /usr/bin/


### PR DESCRIPTION
The c2rust program (required in addition to Rust itself) is installed
for what is for most intents and purposes a third party container, but
happens to have its sources shipped along the other containers.

---

This is a minimal version competing with #141 -- we can still get c2rust to fully integrate over time, but right now there's a third party (happens to be me) who publishes a suitable base container, which is not much more or less transparently managed than any other base container (especially immunant/c2rust which it itself is based on), and hey by the way even the Dockerfile for that container is shipped here (but more for informational purposes, not because CI would access it).