### PR TITLE
Build C2Rust on focal

### DIFF
--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -65,7 +65,9 @@ RUN \
 #
 # # Cleaning up as the relevant files were copied out, and the rest would just
 # # make for a large image (which should only contain a minimal delta to the base
-# # image in the end)
+# # image in the end: the installed dependencies (libllvm), the installed
+# # binaries and the debs that contain the stripped binaries and separate debug
+# # symbols once more)
 # RUN \
     rm -rf c2rust && \
     rm -rf ~/.cargo && \

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -1,4 +1,30 @@
-FROM immunant/c2rust:ubuntu-bionic-latest as c2rust
+#FROM immunant/c2rust:ubuntu-bionic-latest as c2rust
+# Could use ../riotdocker-base after <https://github.com/RIOT-OS/riotdocker/pull/104>.
+FROM ubuntu:focal
+
+# noninteractive for the tzinfo that gets pulled in through cmake
+RUN \
+    echo 'Update the package index files to latest available versions' >&2 && \
+    apt-get update && \
+    echo 'Install Build / install dependencies' >&2 && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        pkg-config \
+        libclang-dev \
+        libssl-dev \
+        llvm-dev \
+        && \
+    echo 'Clean up installation files' >&2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Note that --profile minimal doesn't cut it
+RUN \
+    echo 'Install c2rust rust nightly' >&2 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05
 
 # --locked --git --branch ignores --locked; new (2021-03-something) cargo
 # versions behave properly, but C2Rust is on a 2019-12-05 toolchain.
@@ -6,6 +32,7 @@ FROM immunant/c2rust:ubuntu-bionic-latest as c2rust
 # Cleaning up cargo home again as set by C2Rust image (that's what contributes
 # most to the delta between the immunant container and this one).
 RUN git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
-    cargo install --locked --root /usr --path c2rust/c2rust && \
+    ~/.cargo/bin/cargo install --locked --root /usr --path c2rust/c2rust && \
     rm -rf c2rust && \
-    rm -rf ${CARGO_HOME}
+    rm -rf ~/.cargo \
+    rm -rf ~/.rustup

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -2,6 +2,9 @@
 # Could use ../riotdocker-base after <https://github.com/RIOT-OS/riotdocker/pull/104>.
 FROM ubuntu:focal
 
+COPY debian/control /dpkg-build/debian/
+COPY debian/rules /dpkg-build/debian/
+
 # noninteractive for the tzinfo
 #
 # The first block is for actually building c2rust, the second for building a
@@ -26,28 +29,29 @@ RUN \
         dpkg-dev \
         && \
     echo 'Clean up installation files' >&2 && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Note that --profile minimal doesn't cut it
-RUN \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+#     true
+#
+# # Note that --profile minimal doesn't cut it
+# RUN \
     echo 'Install c2rust rust nightly' >&2 && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05
-
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05 && \
+#     true
+#
 # --locked --git --branch ignores --locked; new (2021-03-something) cargo
 # versions behave properly, but C2Rust is on a 2019-12-05 toolchain.
-RUN git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
-    ~/.cargo/bin/cargo install --locked --path c2rust/c2rust
-
-COPY debian/control /dpkg-build/debian/
-COPY debian/rules /dpkg-build/debian/
-
-# Rather than going through manual motions like suggested in
-# https://bugs.debian.org/993498 (using dpkg-shlibdeps to find which of the
-# packages pulled through build-deps are actually needed), builing a package is
-# really easy as long as no standards apply.
+# RUN \
+    git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
+    ~/.cargo/bin/cargo install --locked --path c2rust/c2rust && \
+#     true
 #
-# (The `cp` should be c2rust*, but <https://github.com/immunant/c2rust/issues/349>).
-RUN \
+# # Rather than going through manual motions like suggested in
+# # https://bugs.debian.org/993498 (using dpkg-shlibdeps to find which of the
+# # packages pulled through build-deps are actually needed), builing a package is
+# # really easy as long as no standards apply.
+# #
+# # (The `cp` should be c2rust*, but <https://github.com/immunant/c2rust/issues/349>).
+# RUN \
     mkdir -p /dpkg-build/debian && \
     cd /dpkg-build && \
     cp -a ~/.cargo/bin/c2rust ~/.cargo/bin/c2rust-transpile . && \
@@ -56,25 +60,28 @@ RUN \
     echo 10 > debian/compat && \
     dpkg-buildpackage -b && \
     cd / && \
-    rm -rf /dpkg-build
-
-# Cleaning up as the relevant files were copied out, and the rest would just
-# make for a large image (which should only contain a minimal delta to the base
-# image in the end)
-RUN \
+    rm -rf /dpkg-build && \
+#     true
+#
+# # Cleaning up as the relevant files were copied out, and the rest would just
+# # make for a large image (which should only contain a minimal delta to the base
+# # image in the end)
+# RUN \
     rm -rf c2rust && \
     rm -rf ~/.cargo && \
-    rm -rf ~/.rustup
-
-# Besides copying the c2rust files to /usr/bin (which could also have been done
-# with --root /usr in the cargo line), this also ensures that the dependencies
-# stick around through the next step.
-RUN \
-    apt-get -y install /c2rust_0.0_*.deb
-
-# TBD: Deduplicate list with above; feisty apt-get has no --mark-auto,
-# otherwise we could just --mark-auto above and autoremove --purge here.
-RUN \
+    rm -rf ~/.rustup && \
+#     true
+#
+# # Besides copying the c2rust files to /usr/bin (which could also have been done
+# # with --root /usr in the cargo line), this also ensures that the dependencies
+# # stick around through the next step.
+# RUN \
+    apt-get -y install /c2rust_0.0_*.deb && \
+#     true
+#
+# # TBD: Deduplicate list with above; feisty apt-get has no --mark-auto,
+# # otherwise we could just --mark-auto above and autoremove --purge here.
+# RUN \
     echo 'Removing packages only needed for building from container' >&2 && \
     apt-get purge -y --auto-remove \
         build-essential \

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -2,12 +2,15 @@
 # Could use ../riotdocker-base after <https://github.com/RIOT-OS/riotdocker/pull/104>.
 FROM ubuntu:focal
 
-# noninteractive for the tzinfo that gets pulled in through cmake
+# noninteractive for the tzinfo
+#
+# The first block is for actually building c2rust, the second for building a
+# Debian package.
 RUN \
     echo 'Update the package index files to latest available versions' >&2 && \
     apt-get update && \
     echo 'Install Build / install dependencies' >&2 && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         cmake \
@@ -17,6 +20,10 @@ RUN \
         libclang-dev \
         libssl-dev \
         llvm-dev \
+        \
+        debhelper \
+        devscripts \
+        dpkg-dev \
         && \
     echo 'Clean up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -28,11 +35,64 @@ RUN \
 
 # --locked --git --branch ignores --locked; new (2021-03-something) cargo
 # versions behave properly, but C2Rust is on a 2019-12-05 toolchain.
-#
-# Cleaning up cargo home again as set by C2Rust image (that's what contributes
-# most to the delta between the immunant container and this one).
 RUN git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
-    ~/.cargo/bin/cargo install --locked --root /usr --path c2rust/c2rust && \
+    ~/.cargo/bin/cargo install --locked --path c2rust/c2rust
+
+COPY debian/control /dpkg-build/debian/
+COPY debian/rules /dpkg-build/debian/
+
+# Rather than going through manual motions like suggested in
+# https://bugs.debian.org/993498 (using dpkg-shlibdeps to find which of the
+# packages pulled through build-deps are actually needed), builing a package is
+# really easy as long as no standards apply.
+#
+# (The `cp` should be c2rust*, but <https://github.com/immunant/c2rust/issues/349>).
+RUN \
+    mkdir -p /dpkg-build/debian && \
+    cd /dpkg-build && \
+    cp -a ~/.cargo/bin/c2rust ~/.cargo/bin/c2rust-transpile . && \
+    ls -1 c2rust* | sed 's@$@ usr/bin@' > debian/install && \
+    EDITOR=true dch --create --package c2rust --newversion 0.0 && \
+    echo 10 > debian/compat && \
+    dpkg-buildpackage -b && \
+    cd / && \
+    rm -rf /dpkg-build
+
+# Cleaning up as the relevant files were copied out, and the rest would just
+# make for a large image (which should only contain a minimal delta to the base
+# image in the end)
+RUN \
     rm -rf c2rust && \
-    rm -rf ~/.cargo \
+    rm -rf ~/.cargo && \
     rm -rf ~/.rustup
+
+# Besides copying the c2rust files to /usr/bin (which could also have been done
+# with --root /usr in the cargo line), this also ensures that the dependencies
+# stick around through the next step.
+RUN \
+    apt-get -y install /c2rust_0.0_*.deb
+
+# TBD: Deduplicate list with above; feisty apt-get has no --mark-auto,
+# otherwise we could just --mark-auto above and autoremove --purge here.
+RUN \
+    echo 'Removing packages only needed for building from container' >&2 && \
+    apt-get purge -y --auto-remove \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        pkg-config \
+        libclang-dev \
+        libssl-dev \
+        llvm-dev \
+        \
+        debhelper \
+        devscripts \
+        dpkg-dev \
+        && \
+    echo 'Cleanup done'
+
+# Check they're still executable
+RUN c2rust --version
+RUN c2rust-transpile --version

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -1,6 +1,5 @@
-#FROM immunant/c2rust:ubuntu-bionic-latest as c2rust
-# Could use ../riotdocker-base after <https://github.com/RIOT-OS/riotdocker/pull/104>.
-FROM ubuntu:focal
+ARG DOCKER_REGISTRY="riot"
+FROM ${DOCKER_REGISTRY}/riotdocker-base:latest
 
 COPY debian/control /dpkg-build/debian/
 COPY debian/rules /dpkg-build/debian/

--- a/c2rust-built/README.md
+++ b/c2rust-built/README.md
@@ -9,6 +9,13 @@ but manually built an published as:
 
     docker build . -t chrysn/c2rust-built
 
+The resulting image fulfils three roles:
+
+* c2rust can be executed in there immediately, or used as a base for other images.
+* The binaries in `/usr/bin/c2rust` can be extracted and used in other images.
+* The `./c2rust_0.0_amd64.deb` package can be copied and installed in other images.
+  Unlike copying the binaries over, this also ensures that the right LLVM dependencies are installed there.
+
 [c2rust]: https://github.com/immunant/c2rust
 [does not release binaries]: https://github.com/immunant/c2rust/issues/326
 [branch this is built from (for-riot)]: https://github.com/chrysn-pull-requests/c2rust/tree/for-riot

--- a/c2rust-built/debian/control
+++ b/c2rust-built/debian/control
@@ -1,0 +1,13 @@
+Source: c2rust
+Section: devel
+Priority: extra
+Maintainer: Christian Amsüss <chrysn@fsfe.org>
+Build-Depends: debhelper (>= 7)
+
+Package: c2rust
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: c2rust transpiler
+ A tool to translate C modules into semantically equivalent Rust code.
+ .
+ This package is built as part of RIOT's docker image creation.

--- a/c2rust-built/debian/rules
+++ b/c2rust-built/debian/rules
@@ -1,0 +1,5 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+
+%:
+	dh $@

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -34,6 +34,9 @@ RUN mkdir /pkgs
 COPY files/libsocketcan-dev_0.0.11-1_i386.deb /pkgs/libsocketcan-dev_0.0.11-1_i386.deb
 COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 
+# After a transition, the :focal can become implicit :latest
+COPY --from=chrysn/c2rust-built:focal /c2rust_0.0_amd64.deb /pkgs
+
 # The following package groups will be installed:
 # - update the package index files to latest available version
 # - native platform development and build system functionality (about 400 MB installed)
@@ -100,9 +103,6 @@ RUN \
         llvm \
         clang \
         clang-tools \
-    && echo 'Installing LLVM version needed by the C2Rust binaries' >&2 && \
-    apt-get -y --no-install-recommends install \
-        llvm-7-dev \
         && \
     SYMS=$(find /usr/bin -type l) && \
     for file in ${SYMS}; do \
@@ -307,6 +307,3 @@ ENV RIOTBUILD_BRANCH $RIOTBUILD_BRANCH
 RUN echo "RIOTBUILD_VERSION=$RIOTBUILD_VERSION" > /etc/riotbuild
 RUN echo "RIOTBUILD_COMMIT=$RIOTBUILD_COMMIT" >> /etc/riotbuild
 RUN echo "RIOTBUILD_BRANCH=$RIOTBUILD_BRANCH" >> /etc/riotbuild
-
-# These depend on llvm-7-dev to be installed
-COPY --from=chrysn/c2rust-built /usr/bin/c2rust /usr/bin/c2rust-refactor /usr/bin/c2rust-transpile /usr/bin/


### PR DESCRIPTION
This issue tracks changes needed in the Rust installation (OK: C2Rust -- the rest should just work) when #104 is rebased and gets merged.

By building c2rust on the same Ubuntu release (focal), the friction between different installed LLVM versions will be reduced.

This
* switches from using c2rust's shipped build containers (which made sense back when supported Ubuntus had those old LLVM versions) to a plain feisty base,
* consequently installs the build-deps manually, and
* builds a Debian binary package in the course of installing c2rust.

The latter is done to get us rid of the manual `apt-get install llvm-7-dev` (and pray that it matches what c2rust needs) in favor of copying the .deb out of the c2rust image and getting the right build-deps automatically. (A part of building a Debian package is the tools inspecting any binaries for used shared libraries, looking up the packages they're in, and looking at that library's exported symbol versionings to get a correctly version for the dependency).

<del>Put on hold / WIP / draft until #104 is done, given that these don't need lockstepping yet.</del>