### PR TITLE
.github/workflows/build.yml: bump verison to 2022.01

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2021.07-branch'
-      VERSION_TAG: '2021.10'
+      RIOT_BRANCH: '2021.10-branch'
+      VERSION_TAG: '2022.01'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:


### PR DESCRIPTION
This PR should wait for the 2021.10 release to be in