### PR TITLE
static-test-tools: use uncrustify from kaspar030/uncrustify-builder

### DIFF
--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -21,7 +21,6 @@ RUN \
         make \
         pcregrep \
         shellcheck \
-        uncrustify \
         vera++ \
         wget \
         && \
@@ -33,3 +32,6 @@ COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 && \
     pip3 install --no-cache-dir -r /tmp/requirements.txt && \
     rm -f /tmp/requirements.txt
+
+# Install uncrustify
+COPY --from=ghcr.io/kaspar030/uncrustify-builder:latest /usr/bin/uncrustify /usr/bin/uncrustify


### PR DESCRIPTION
Alternative to https://github.com/RIOT-OS/riotdocker/pull/139.

kaspar030/uncrustify-builder now builds and publishes a container with recent uncrustify binary, which can simply be copied from there.

This upgrades riot/riotbuild's Uncrustify to versoin 0.73.0!