### PR TITLE
riotbuild: use pycryptodome instead of pycrypto

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -2,7 +2,7 @@
 pyasn1==0.4.2
 ecdsa==0.13.3
 pexpect==4.8.0
-pycrypto==2.6.1
+pycryptodome==3.11.0        # used by mcuboot
 pyserial==3.4
 ed25519==1.4
 cbor==1.0.0


### PR DESCRIPTION
This replaces the [unmaintained `pycrypto`](https://github.com/pycrypto/pycrypto/issues/173) (which has several vulnerabilities, see https://github.com/RIOT-OS/RIOT/pull/17107) with the more up-to-date [`pycryptodome`](https://pypi.org/project/pycryptodome/).