### PR TITLE
murdock-worker: bump dwq

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -20,7 +20,7 @@ RUN \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install dwq (disque work queue)
-RUN pip3 install dwq==0.0.41
+RUN pip3 install dwq==0.0.49
 
 # install testrunner dependencies
 RUN pip3 install click


### PR DESCRIPTION
bump the dwq tool to ~~0.0.47~~ 0.0.49.

This does not affect riotdocker, only the murdock-worker.
dwq version 0.0.47 has some features that make deploying it with docker-compose a bit easier (mostly, not hard-coding "localhost:7711" for it's disque url).

dwq 0.0.49 brings some bug fixes to dwqw. There's also better reporting (now the checkout time and output is logged in result.json).