### PR TITLE
Rust updates

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -280,11 +280,16 @@ ENV PATH ${PATH}:/opt/rustup/.cargo/bin
 # toolchain add` or similar; CARGO_HOME is not because the user will need to
 # write there, and all rustup does here is to place some binaries that later
 # fan out to RUSTUP_HOME anyway.
+#
+# Components: rust-src is needed to run `-Z build-std=core`, which in turn is
+# needed on AVR (which thus doesn't need the avr-unknown-gnu-atmega328 target;
+# being able to build core might be useful for other targets as well).
 ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2021-08-28 && \
+    rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \
     rustup target add thumbv7em-none-eabihf && \

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -288,7 +288,7 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2021-08-28 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2021-11-10 && \
     rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \


### PR DESCRIPTION
* Add what is needed to experiment with AVR (not fully supported for Rust-on-RIOT, but way easier to test being in the docker build as I haven't had AVR toolchains installed around for a long time, though they probably still can be installed easily)
* Update Rust nightly (that's a semi-regular thing since we decided to pin the version in https://github.com/RIOT-OS/riotdocker/pull/141#issuecomment-909035011 which also went into #152)