### PR TITLE
riotbuild: Drop :focal tag in favor of a more stable one

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -34,8 +34,7 @@ RUN mkdir /pkgs
 COPY files/libsocketcan-dev_0.0.11-1_i386.deb /pkgs/libsocketcan-dev_0.0.11-1_i386.deb
 COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 
-# After a transition, the :focal can become implicit :latest
-COPY --from=chrysn/c2rust-built:focal /c2rust_0.0_amd64.deb /pkgs
+COPY --from=chrysn/c2rust-built:for-riot /c2rust_0.0_amd64.deb /pkgs
 
 # The following package groups will be installed:
 # - update the package index files to latest available version


### PR DESCRIPTION
This drops a workaround that was necessary during evaluation of #153 in
favor of a more long-term usable distinction between experimentation and
stable delivery, which is necessary until #141 is done properly and
c2rust is built in one go with the rest of this.

---

Cleanup change with no expected actual impact. (Tags diverge because `latest` = `for-riot` was rebuilt after #153 was merged, but any differences should be just because building is not byte-by-byte reproducible.)