### PR TITLE
murdock: Install hiredis

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -22,6 +22,10 @@ RUN \
 # install dwq (disque work queue)
 RUN pip3 install dwq==0.0.41
 
+# install hiredis -- not required directly, but redis (from dwq) will spew
+# warnings otherwise that break things somewhere further down the line.
+RUN pip3 install hiredis
+
 # install testrunner dependencies
 RUN pip3 install click
 


### PR DESCRIPTION
The latest redis-py pulled through dwq spews out a [warning](https://github.com/redis/redis-py/blob/4e9cc015e32ef305429ff9dfa200e28dd63e6663/redis/connection.py#L71) if hiredis is not installed.

Somewhere down the line, that gets turned into a job, and produces murdock output like:

> **Failed jobs**: [UserWarning:/redis-py/works/best/with/hiredis./Please/consider/installing](https://ci.riot-os.org/RIOT-OS/RIOT/17221/b2f9e2c226e7c26abaf22228b2aa396fb85df6e3/output/UserWarning:/redis-py/works/best/with/hiredis./Please/consider/installing.txt)

This is a hotfix that makes the warning go away; where the warning (that should go to stderr and not into jobs) took the wrong turn is yet to be explored.

## Testing

Build the murdock container and run:

```
$ python3 -c 'import dwq'
```

If all is well, that should return immediately and not print any warning.