### PR TITLE
rust: Add support for Cortex-M23, M33 and M33F

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -295,6 +295,9 @@ RUN \
     rustup target add thumbv7em-none-eabi && \
     rustup target add thumbv7m-none-eabi && \
     rustup target add thumbv6m-none-eabi && \
+    rustup target add thumbv8m.main-none-eabihf && \
+    rustup target add thumbv8m.main-none-eabi && \
+    rustup target add thumbv8m.base-none-eabi && \
     true"
 
 # get Dockerfile version from build args


### PR DESCRIPTION
This is not aimed for in https://github.com/RIOT-OS/RIOT/pull/16274, but progressively opening up to more architectures, build servers will need this.