### PR TITLE
riotbuild: add qemu-system-arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,16 @@ jobs:
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
           BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native pic32-wifire samr21-xpro"
 
+      - name: GNU microbit qemu test
+        run: >
+          docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild
+          ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          make -Ctests/fmt_print all test
+
+        env:
+          BOARD: "microbit"
+          EMULATE: 1
+
       - name: LLVM build test
         run: |
           make -CRIOT/examples/hello-world buildtest

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=chrysn/c2rust-built:for-riot /c2rust_0.0_amd64.deb /pkgs
 # - MSP430 development (about 120 MB installed)
 # - AVR development (about 110 MB installed)
 # - LLVM/Clang build environment (about 125 MB installed)
+# - QEMU
 # All apt files will be deleted afterwards to reduce the size of the container image.
 # The OS must not be updated by apt. Docker image should be build against the latest
 #  updated base OS image. This can be forced with `--pull` flag.
@@ -79,7 +80,9 @@ RUN \
         python3-setuptools \
         python3-wheel \
         p7zip \
+        qemu-system-arm \
         rsync \
+        socat \
         ssh-client \
         subversion \
         unzip \


### PR DESCRIPTION
This PR adds QEMU with it's full-system ARM emulator.

At least the microbit board can be emulated to a large degree with this.

A second commit adds a basic test run of `tests/fmt_print` for microbit, using qemu.