### PR TITLE
Update Rust nightly version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,22 @@ jobs:
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
           BOARDS: "native samr21-xpro"
 
+      - name: Rust build test
+        run: |
+          # Once 2022.01 is released, the switcharoo can be removed.
+          # Note that `git switch master` does not work because the checkout
+          # action does only minimal fetching.
+          (cd RIOT && git fetch origin master && git checkout FETCH_HEAD)
+          make -CRIOT/examples/rust-hello-world buildtest
+          (cd RIOT && git switch -)
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          # Not all of them are actually available; still using the "canonical"
+          # list of representative boards above to keep this stable whil Rust
+          # support expands
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native pic32-wifire samr21-xpro"
+
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -290,7 +290,7 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2021-11-10 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-01-07 && \
     rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \


### PR DESCRIPTION
With this version it will be possible to use cstr_core >= 0.2.5 (which
future versions of riot-wrappers will depend on)

Testing procedure: Things still build.