### PR TITLE
murdock-worker: bump disque to 0.0.50

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -20,7 +20,7 @@ RUN \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install dwq (disque work queue)
-RUN pip3 install dwq==0.0.49
+RUN pip3 install dwq==0.0.50
 
 # install hiredis -- not required directly, but redis (from dwq) will spew
 # warnings otherwise that break things somewhere further down the line.


### PR DESCRIPTION
Bumping dwq, integrating a small bugfix (from https://github.com/kaspar030/dwq/pull/3).