### PR TITLE
murdock-worker: bump dwq to 0.0.51

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -20,7 +20,7 @@ RUN \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install dwq (disque work queue)
-RUN pip3 install dwq==0.0.50
+RUN pip3 install dwq==0.0.51
 
 # install hiredis -- not required directly, but redis (from dwq) will spew
 # warnings otherwise that break things somewhere further down the line.


### PR DESCRIPTION
bumping dwq again.

0.0.51 has a small change, increasing the safety margin the worker uses to time-out jobs itself. This is to prevent a job from being timed-out by disque server, at which point it's output would be lost.