### PR TITLE
C2Rust: Use upstream as patches are not required any more

### DIFF
--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -2,13 +2,17 @@ ARG DOCKER_REGISTRY="riot"
 FROM ${DOCKER_REGISTRY}/riotdocker-base:latest
 
 COPY debian/control /dpkg-build/debian/
+# When playing with these, it is often practical to remove the comments on the
+# `# true` / ... / `# RUN \` blocks (making the resulting images larger because
+# of the intermediate files in the chain, but quick to rebuild on small
+# changes) and moving the COPY lines down before the `dpkg-buildpackage` to not
+# download and install all the dependencies again. The control file needs to
+# stay up there as it influences what will be installed.
 COPY debian/rules /dpkg-build/debian/
 COPY debian/changelog /dpkg-build/debian/
+COPY debian/install /dpkg-build/debian/
 
 # noninteractive for the tzinfo
-#
-# The first block is for actually building c2rust, the second for building a
-# Debian package.
 RUN \
     echo 'Update the package index files to latest available versions' >&2 && \
     apt-get update && \
@@ -17,13 +21,13 @@ RUN \
         build-essential \
         ca-certificates \
         curl \
-        git \
-        \
         debhelper \
         devscripts \
         dpkg-dev \
+        equivs \
+        git \
         && \
-    mk-build-deps -i /dpkg-build/debian/control && \
+    mk-build-deps -i /dpkg-build/debian/control -t 'apt-get -y --no-install-recommends' && \
     echo 'Clean up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 #     true
@@ -34,32 +38,23 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05 && \
 #     true
 #
-# Pinned to 6674d785 because that is know to work with 2019-12-05; upgrading
-# this should be unproblematic, but will need the right nightly set.
-#
-# --locked --git --rev ignores --locked so an explicit checkout is done
-# instead; new (2021-03-something) cargo versions behave properly, but C2Rust
-# is on a 2019-12-05 toolchain.
-# RUN \
-    git clone --recursive https://github.com/immunant/c2rust && \
-    git -C c2rust reset --hard 6674d785 && \
-    ~/.cargo/bin/cargo install --locked --path c2rust/c2rust && \
-#     true
-#
-# # Rather than going through manual motions like suggested in
-# # https://bugs.debian.org/993498 (using dpkg-shlibdeps to find which of the
-# # packages pulled through build-deps are actually needed), builing a package is
-# # really easy as long as no standards apply.
+# # Build using the provided Debian package sources
 # #
-# # (The `cp` should be c2rust*, but <https://github.com/immunant/c2rust/issues/349>).
+# # Pinned to 6674d785 because that is know to work with 2019-12-05; upgrading
+# # this should be unproblematic, but will need the right nightly set.
+# #
 # RUN \
     mkdir -p /dpkg-build/debian && \
     cd /dpkg-build && \
-    cp -a ~/.cargo/bin/c2rust ~/.cargo/bin/c2rust-transpile . && \
-    ls -1 c2rust* | sed 's@$@ usr/bin@' > debian/install && \
-    dpkg-buildpackage -b && \
+    git clone --recursive https://github.com/immunant/c2rust && \
+    git -C c2rust reset --hard 6674d785 && \
+#     true
+#
+# # Build using Debian's mechanism; the actual build line is in ./debian/rules
+# RUN \
+    cd /dpkg-build && \
+    PATH=~/.cargo/bin:$PATH dpkg-buildpackage -b && \
     cd / && \
-    rm -rf /dpkg-build && \
 #     true
 #
 # # Cleaning up as the relevant files were copied out, and the rest would just
@@ -68,7 +63,7 @@ RUN \
 # # binaries and the debs that contain the stripped binaries and separate debug
 # # symbols once more)
 # RUN \
-    rm -rf c2rust && \
+    rm -rf /dpkg-build && \
     rm -rf ~/.cargo && \
     rm -rf ~/.rustup && \
 #     true
@@ -77,7 +72,7 @@ RUN \
 # # with --root /usr in the cargo line), this also ensures that the dependencies
 # # stick around through the next step.
 # RUN \
-    apt-get -y install /c2rust_0.0_*.deb && \
+    apt-get -y install /c2rust_*.deb && \
 #     true
 #
 # # TBD: Deduplicate list with above; feisty apt-get has no --mark-auto,
@@ -88,12 +83,12 @@ RUN \
         build-essential \
         ca-certificates \
         curl \
-        git \
-        \
         debhelper \
         devscripts \
         dpkg-dev \
-        c2rust-build-dep \
+        equivs \
+        git \
+        c2rust-build-deps \
         && \
     echo 'Cleanup done'
 

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -3,6 +3,7 @@ FROM ${DOCKER_REGISTRY}/riotdocker-base:latest
 
 COPY debian/control /dpkg-build/debian/
 COPY debian/rules /dpkg-build/debian/
+COPY debian/changelog /dpkg-build/debian/
 
 # noninteractive for the tzinfo
 #
@@ -56,7 +57,6 @@ RUN \
     cd /dpkg-build && \
     cp -a ~/.cargo/bin/c2rust ~/.cargo/bin/c2rust-transpile . && \
     ls -1 c2rust* | sed 's@$@ usr/bin@' > debian/install && \
-    EDITOR=true dch --create --package c2rust --newversion 0.0 && \
     dpkg-buildpackage -b && \
     cd / && \
     rm -rf /dpkg-build && \

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -37,10 +37,15 @@ RUN \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05 && \
 #     true
 #
-# --locked --git --branch ignores --locked; new (2021-03-something) cargo
-# versions behave properly, but C2Rust is on a 2019-12-05 toolchain.
+# Pinned to 6674d785 because that is know to work with 2019-12-05; upgrading
+# this should be unproblematic, but will need the right nightly set.
+#
+# --locked --git --rev ignores --locked so an explicit checkout is done
+# instead; new (2021-03-something) cargo versions behave properly, but C2Rust
+# is on a 2019-12-05 toolchain.
 # RUN \
-    git clone --recursive https://github.com/chrysn-pull-requests/c2rust -b for-riot && \
+    git clone --recursive https://github.com/immunant/c2rust && \
+    git -C c2rust reset --hard 6674d785 && \
     ~/.cargo/bin/cargo install --locked --path c2rust/c2rust && \
 #     true
 #

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -15,18 +15,14 @@ RUN \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
-        cmake \
         curl \
         git \
-        pkg-config \
-        libclang-dev \
-        libssl-dev \
-        llvm-dev \
         \
         debhelper \
         devscripts \
         dpkg-dev \
         && \
+    mk-build-deps -i /dpkg-build/debian/control && \
     echo 'Clean up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 #     true
@@ -91,17 +87,13 @@ RUN \
     apt-get purge -y --auto-remove \
         build-essential \
         ca-certificates \
-        cmake \
         curl \
         git \
-        pkg-config \
-        libclang-dev \
-        libssl-dev \
-        llvm-dev \
         \
         debhelper \
         devscripts \
         dpkg-dev \
+        c2rust-build-dep \
         && \
     echo 'Cleanup done'
 

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -61,7 +61,6 @@ RUN \
     cp -a ~/.cargo/bin/c2rust ~/.cargo/bin/c2rust-transpile . && \
     ls -1 c2rust* | sed 's@$@ usr/bin@' > debian/install && \
     EDITOR=true dch --create --package c2rust --newversion 0.0 && \
-    echo 10 > debian/compat && \
     dpkg-buildpackage -b && \
     cd / && \
     rm -rf /dpkg-build && \

--- a/c2rust-built/README.md
+++ b/c2rust-built/README.md
@@ -1,6 +1,5 @@
 This image contains built and usable versions of [c2rust].
-It is provided because upstream [does not release binaries] for c2rust and its companion tools,
-and because the [branch this is built from (for-riot)] contains some fixes to c2rust required to work on RIOT.
+It is provided because upstream [does not release binaries] for c2rust and its companion tools.
 
 As this changes rarely,
 and because on the github-workers infrastructure this is [difficult to get right],
@@ -15,6 +14,15 @@ The resulting image fulfils three roles:
 * The binaries in `/usr/bin/c2rust` can be extracted and used in other images.
 * The `./c2rust_0.0_amd64.deb` package can be copied and installed in other images.
   Unlike copying the binaries over, this also ensures that the right LLVM dependencies are installed there.
+
+The parts that can be meaningfully performed by a Debian package are,
+and the relevant files are located in the `debian/` directory.
+As a side effect,
+packages can be built using the same infrastructure even without a Docker container:
+as long as the right Rust nightly version is present
+and all the typical Debian tools are around,
+c2rust can be checked out under this directory,
+and `dpkg-buildpackage -b` will produce a usable package for the Debian (or derivative) installed on the system.
 
 [c2rust]: https://github.com/immunant/c2rust
 [does not release binaries]: https://github.com/immunant/c2rust/issues/326

--- a/c2rust-built/debian/changelog
+++ b/c2rust-built/debian/changelog
@@ -1,0 +1,5 @@
+c2rust (0.0) UNRELEASED; urgency=medium
+
+  * Initial package as part of the riotdocker builds.
+
+ -- Christian M. Amsüss <chrysn@fsfe.org>  Tue, 08 Mar 2022 16:22:14 +0100

--- a/c2rust-built/debian/control
+++ b/c2rust-built/debian/control
@@ -2,7 +2,7 @@ Source: c2rust
 Section: devel
 Priority: extra
 Maintainer: Christian Amsüss <chrysn@fsfe.org>
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper-compat (= 12)
 
 Package: c2rust
 Architecture: any

--- a/c2rust-built/debian/control
+++ b/c2rust-built/debian/control
@@ -2,11 +2,16 @@ Source: c2rust
 Section: devel
 Priority: extra
 Maintainer: Christian Amsüss <chrysn@fsfe.org>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: cmake,
+               debhelper-compat (= 12),
+               libclang-dev,
+               libssl-dev,
+               llvm-dev,
+               pkg-config
 
 Package: c2rust
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: c2rust transpiler
  A tool to translate C modules into semantically equivalent Rust code.
  .

--- a/c2rust-built/debian/install
+++ b/c2rust-built/debian/install
@@ -1,0 +1,2 @@
+c2rust/target/release/c2rust usr/bin
+c2rust/target/release/c2rust-transpile usr/bin

--- a/c2rust-built/debian/rules
+++ b/c2rust-built/debian/rules
@@ -3,3 +3,6 @@
 
 %:
 	dh $@
+
+override_dh_auto_install:
+	cargo +"`cat c2rust/rust-toolchain`" build --manifest-path c2rust/c2rust/Cargo.toml --locked --release


### PR DESCRIPTION
C2Rust has accepted most of the patches in the current for-riot; what's left needs riot-sys fixes anyway on the long run.

### Issues/PRs references

A sibling PR on RIOT docs is https://github.com/RIOT-OS/RIOT/pull/17536

### Status

This is on hold as a draft because it still depends on two things:

* [x] The no-llvm-asm branch of riot-wrappers to be merged, released and the Cargo.lock files here to be updated to use it, and
* [x] The unpatched C2Rust won't work for older Rust-on-RIOT versions (fixable with a `cargo update`, but that shouldn't be necessary for users to do to run the demos), so this will need to wait until the current release is through
 
-- and then maybe some time for good measure as to not cause any trouble for people on branches that haven't received the no-llvm-asm riot-wrappers update from RIOT yet.

[edit: Turned into a checklist, as first item is done]