### PR TITLE
riotbuild/Dockerfile: add libsdl2-dev:i386wq

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -61,6 +61,7 @@ RUN \
         libffi-dev \
         libpcre3 \
         libtool \
+        libsdl2-dev:i386 \
         m4 \
         ninja-build \
         parallel \


### PR DESCRIPTION
This PR adds SDL to build SDL applications for native, e.g.: https://github.com/RIOT-OS/RIOT/pull/16944.

To test I would suggest building the image locally and testing the PR:

```
$ docker build -f riotbuild/Dockerfile . --tag test/riotsdl
```

```
$ DOCKER_IMAGE=test/riotsdl BUILD_IN_DOCKER=1 BOARD=native make -C tests/pkg_lvgl flash term
```

@benpicco 