### PR TITLE
murdock-worker: bump dwq to 0.0.52

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -20,7 +20,7 @@ RUN \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install dwq (disque work queue)
-RUN pip3 install dwq==0.0.51
+RUN pip3 install dwq==0.0.52
 
 # install hiredis -- not required directly, but redis (from dwq) will spew
 # warnings otherwise that break things somewhere further down the line.


### PR DESCRIPTION
Bump dwq,

upstream contains this commit (apart from the version bump):

https://github.com/kaspar030/dwq/commit/05ae117526d7dbcbac381d53bd9e20d1af8cbc0e