### PR TITLE
CI: add pkg_nanopb test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,12 @@ jobs:
           BOARD: "microbit"
           EMULATE: 1
 
+      - name: tests/nanopb test
+        run: >
+          docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild
+          ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          make -Ctests/pkg_nanopb all test
+
       - name: LLVM build test
         run: |
           make -CRIOT/examples/hello-world buildtest


### PR DESCRIPTION
This should ensure the installed nanopb package works correctly.

Once merged, https://github.com/RIOT-OS/riotdocker/pull/181 can probably be merged safely.