### PR TITLE
riotbuild: avoid errors when emlearn is installed

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -269,6 +269,7 @@ ENV PATH $PATH:/opt/riot-toolchain/msp430-elf/${RIOT_TOOLCHAIN_GCCPKGVER}/bin
 RUN pip3 install --no-cache-dir numpy==1.17.4
 COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 \
+    && pip3 install --no-cache-dir pybind11 \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 


### PR DESCRIPTION
As reported in issue #184, the installation of `emlearn` seems to fail in because of missing `pybind11` module, but is actually successful. The reason is that the wheels for `ed25519`, `cbor`, `scapy`, `emlearn` and `riotctrl` are built before the other collected packages are installed.

The extensive error output on the first failed iteration of the `emlearn` installation is very confusing and can be prevented by explicitly installing the `pybind` package before installing the other required packages, as suggested in this PR.