### PR TITLE
rust: Update nightly version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,11 @@ jobs:
 
       - name: Rust build test
         run: |
-          # Once 2022.01 is released, the switcharoo can be removed.
+          # Once a release is out that can be built on stable, this switcharoo
+          # can be removed -- until then, each release of RIOT is only
+          # supported with the very Rust version that was the configured
+          # nightly it was released with; such is the nature of nightly.
+          #
           # Note that `git switch master` does not work because the checkout
           # action does only minimal fetching.
           (cd RIOT && git fetch origin master && git checkout FETCH_HEAD)

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -292,7 +292,7 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-01-07 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-03-08 && \
     rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \


### PR DESCRIPTION
This ensures that after the 2020.04 release the supported stable version
can be bumped to Rust 1.61. Using Rust 1.61 to its full potential will
require removing feature declarations, and if riot-wrappers has those
features removed, building it needs a recent nightly (like this) that
does not need them declared.

In addition, it removes a workaround that was needed before the 2022.01 release for the build tests; they are now performed on whatever RIOT branch is selected (IIUC the last release -- anyhow, like all the other build tests).

---

In terms of testing, this should be covered well by the test; in addition, local build tests are being done against the latest RIOT master, and with a larger example than the hello-world.