### PR TITLE
rust: Add beta version

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -293,17 +293,20 @@ RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-03-08 && \
-    rustup component add rust-src && \
-    rustup target add i686-unknown-linux-gnu && \
-    rustup target add riscv32imac-unknown-none-elf && \
-    rustup target add thumbv7em-none-eabihf && \
-    rustup target add thumbv7em-none-eabi && \
-    rustup target add thumbv7m-none-eabi && \
-    rustup target add thumbv6m-none-eabi && \
-    rustup target add thumbv8m.main-none-eabihf && \
-    rustup target add thumbv8m.main-none-eabi && \
-    rustup target add thumbv8m.base-none-eabi && \
-    true"
+    rustup toolchain add beta && \
+    for T in nightly-2022-03-08 beta; do \
+        rustup component add rust-src --toolchain \$T && \
+        rustup target add i686-unknown-linux-gnu --toolchain \$T && \
+        rustup target add riscv32imac-unknown-none-elf --toolchain \$T && \
+        rustup target add thumbv7em-none-eabihf --toolchain \$T && \
+        rustup target add thumbv7em-none-eabi --toolchain \$T && \
+        rustup target add thumbv7m-none-eabi --toolchain \$T && \
+        rustup target add thumbv6m-none-eabi --toolchain \$T && \
+        rustup target add thumbv8m.main-none-eabihf --toolchain \$T && \
+        rustup target add thumbv8m.main-none-eabi --toolchain \$T && \
+        rustup target add thumbv8m.base-none-eabi --toolchain \$T && \
+        true; \
+    done"
 
 # get Dockerfile version from build args
 ARG RIOTBUILD_VERSION=unknown


### PR DESCRIPTION
With builds of RIOT on stable Rust becoming more and more attainable (basics are in, 1.60 is adding builds on native without undue complexity, 1.61 will add support for shell and SAUL), at some point we should make that part of the test suite.

The present commit is a first step there. It adds "beta", but the [plan](https://forum.riot-os.org/t/release-2022-04-dates-and-feature-requests/3548/3) is to switch that over to 'stable' when 1.60 becomes stable.

This likely doubles the size of the installed Rust (rustup itself is common but rather small; compiler, core libraries and source code will be duplicated); the build tests that give me numbers are still running. Possibly, the source code can be left out of the beta image -- that's mainly needed when rebuilding the core libraries to the target spec, which is available only on nightly.