### PR TITLE
rust: 1.60 has been released

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -294,8 +294,8 @@ RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-03-08 && \
-    rustup toolchain add beta && \
-    for T in nightly-2022-03-08 beta; do \
+    rustup toolchain add stable && \
+    for T in nightly-2022-03-08 stable; do \
         rustup component add rust-src --toolchain \$T && \
         rustup target add i686-unknown-linux-gnu --toolchain \$T && \
         rustup target add riscv32imac-unknown-none-elf --toolchain \$T && \


### PR DESCRIPTION
Switching over as planned[1] for the pending release.

[1]: https://forum.riot-os.org/t/release-2022-04-dates-and-feature-requests/3548/3