### PR TITLE
CI: add git safe directory

### DIFF
--- a/riotdocker-base/Dockerfile
+++ b/riotdocker-base/Dockerfile
@@ -28,7 +28,8 @@ RUN mkdir -m 777 -p /data/riotbuild
 
 # Set a global system-wide git user and email address
 RUN git config --system user.name "riot" && \
-    git config --system user.email "riot@example.com"
+    git config --system user.email "riot@example.com" && \
+    git config --system --add safe.directory /data/riotbuild
 
 # Copy our entry point script (signal wrapper)
 COPY run.sh /run.sh


### PR DESCRIPTION
Workaround for https://github.com/actions/checkout/issues/760 (caused by a [git vulnerability](https://github.blog/2022-04-12-git-security-vulnerability-announced/)).