### PR TITLE
Update C2Rust to 0.16

### DIFF
--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -68,6 +68,12 @@ RUN \
     apt-get -y install /c2rust_*.deb && \
 #     true
 #
+# # Provide the package in an easy to match place independent of version and
+# # architecture
+# RUN \
+    cp -l /c2rust_*.deb /c2rust.deb && \
+#     true
+#
 # # TBD: Deduplicate list with above; feisty apt-get has no --mark-auto,
 # # otherwise we could just --mark-auto above and autoremove --purge here.
 # RUN \

--- a/c2rust-built/Dockerfile
+++ b/c2rust-built/Dockerfile
@@ -10,7 +10,6 @@ COPY debian/control /dpkg-build/debian/
 # stay up there as it influences what will be installed.
 COPY debian/rules /dpkg-build/debian/
 COPY debian/changelog /dpkg-build/debian/
-COPY debian/install /dpkg-build/debian/
 
 # noninteractive for the tzinfo
 RUN \
@@ -25,7 +24,6 @@ RUN \
         devscripts \
         dpkg-dev \
         equivs \
-        git \
         && \
     mk-build-deps -i /dpkg-build/debian/control -t 'apt-get -y --no-install-recommends' && \
     echo 'Clean up installation files' >&2 && \
@@ -34,20 +32,15 @@ RUN \
 #
 # # Note that --profile minimal doesn't cut it
 # RUN \
-    echo 'Install c2rust rust nightly' >&2 && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2019-12-05 && \
+    echo 'Install c2rust rust' >&2 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
 #     true
 #
 # # Build using the provided Debian package sources
 # #
-# # Pinned to 6674d785 because that is know to work with 2019-12-05; upgrading
-# # this should be unproblematic, but will need the right nightly set.
-# #
 # RUN \
     mkdir -p /dpkg-build/debian && \
     cd /dpkg-build && \
-    git clone --recursive https://github.com/immunant/c2rust && \
-    git -C c2rust reset --hard 6674d785 && \
 #     true
 #
 # # Build using Debian's mechanism; the actual build line is in ./debian/rules
@@ -87,7 +80,6 @@ RUN \
         devscripts \
         dpkg-dev \
         equivs \
-        git \
         c2rust-build-deps \
         && \
     echo 'Cleanup done'

--- a/c2rust-built/README.md
+++ b/c2rust-built/README.md
@@ -12,7 +12,7 @@ The resulting image fulfils three roles:
 
 * c2rust can be executed in there immediately, or used as a base for other images.
 * The binaries in `/usr/bin/c2rust` can be extracted and used in other images.
-* The `./c2rust_*.deb` package can be copied and installed in other images.
+* The `./c2rust.deb` package can be copied and installed in other images.
   Unlike copying the binaries over, this also ensures that the right LLVM dependencies are installed there.
 
 The parts that can be meaningfully performed by a Debian package are,

--- a/c2rust-built/README.md
+++ b/c2rust-built/README.md
@@ -12,19 +12,17 @@ The resulting image fulfils three roles:
 
 * c2rust can be executed in there immediately, or used as a base for other images.
 * The binaries in `/usr/bin/c2rust` can be extracted and used in other images.
-* The `./c2rust_0.0_amd64.deb` package can be copied and installed in other images.
+* The `./c2rust_*.deb` package can be copied and installed in other images.
   Unlike copying the binaries over, this also ensures that the right LLVM dependencies are installed there.
 
 The parts that can be meaningfully performed by a Debian package are,
 and the relevant files are located in the `debian/` directory.
 As a side effect,
 packages can be built using the same infrastructure even without a Docker container:
-as long as the right Rust nightly version is present
+as long as a recent Rust version is present
 and all the typical Debian tools are around,
-c2rust can be checked out under this directory,
-and `dpkg-buildpackage -b` will produce a usable package for the Debian (or derivative) installed on the system.
+`dpkg-buildpackage -b` will produce a usable package for the Debian (or derivative) installed on the system.
 
 [c2rust]: https://github.com/immunant/c2rust
 [does not release binaries]: https://github.com/immunant/c2rust/issues/326
-[branch this is built from (for-riot)]: https://github.com/chrysn-pull-requests/c2rust/tree/for-riot
 [difficult to get right]: https://github.com/RIOT-OS/riotdocker/pull/141

--- a/c2rust-built/debian/changelog
+++ b/c2rust-built/debian/changelog
@@ -1,5 +1,5 @@
-c2rust (0.0) UNRELEASED; urgency=medium
+c2rust (0.16.0-0) UNRELEASED; urgency=medium
 
   * Initial package as part of the riotdocker builds.
 
- -- Christian M. Amsüss <chrysn@fsfe.org>  Tue, 08 Mar 2022 16:22:14 +0100
+ -- Christian M. Amsüss <chrysn@fsfe.org>  Fri, 13 May 2022 09:06:27 +0200

--- a/c2rust-built/debian/install
+++ b/c2rust-built/debian/install
@@ -1,2 +1,0 @@
-c2rust/target/release/c2rust usr/bin
-c2rust/target/release/c2rust-transpile usr/bin

--- a/c2rust-built/debian/rules
+++ b/c2rust-built/debian/rules
@@ -5,6 +5,6 @@
 	dh $@
 
 override_dh_auto_install:
-	cargo install --no-track --locked c2rust --version 0.16.0 --root debian/c2rust/usr
+	cargo install --no-track --locked c2rust --git https://github.com/chrysn-pull-requests/c2rust --branch for-riot-20220513 --root debian/c2rust/usr
 	# For unknown reasons --no-track doesn't keep cargo from installing .crates.toml and .crates2.json
 	rm -f debian/c2rust/usr/.??*

--- a/c2rust-built/debian/rules
+++ b/c2rust-built/debian/rules
@@ -5,4 +5,6 @@
 	dh $@
 
 override_dh_auto_install:
-	cargo +"`cat c2rust/rust-toolchain`" build --manifest-path c2rust/c2rust/Cargo.toml --locked --release
+	cargo install --no-track --locked c2rust --version 0.16.0 --root debian/c2rust/usr
+	# For unknown reasons --no-track doesn't keep cargo from installing .crates.toml and .crates2.json
+	rm -f debian/c2rust/usr/.??*

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir /pkgs
 COPY files/libsocketcan-dev_0.0.11-1_i386.deb /pkgs/libsocketcan-dev_0.0.11-1_i386.deb
 COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 
-COPY --from=chrysn/c2rust-built:for-riot /c2rust_0.0_amd64.deb /pkgs
+COPY --from=chrysn/c2rust-built:for-riot /c2rust.deb /pkgs
 
 # The following package groups will be installed:
 # - update the package index files to latest available version


### PR DESCRIPTION
Things got a lot easier since upstream did awesome work leading up to https://github.com/immunant/c2rust/issues/365.

This release allows riot-sys to do away with a quite a few workarounds, and resolves a blocker for https://github.com/RIOT-OS/RIOT/pull/18056 in passing.

This is a prerequisite for https://github.com/RIOT-OS/riotdocker/pull/189 (in the course of which C2Rust can then be simplified further, as we can just use Rust from Ubuntu to build it, or even simply let this become a Debian package over time).