### PR TITLE
rust: Update nightly version

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -325,9 +325,9 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-03-08 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-09-13 && \
     rustup toolchain add stable && \
-    for T in nightly-2022-03-08 stable; do \
+    for T in nightly-2022-09-13 stable; do \
         rustup component add rust-src --toolchain \$T && \
         rustup target add i686-unknown-linux-gnu --toolchain \$T && \
         rustup target add riscv32imac-unknown-none-elf --toolchain \$T && \


### PR DESCRIPTION
This allows more precise testing of changes that have stabilized. Concretely, all the changes (cstr in core, generic associated types) that have been stabilized available in the nightly in the form in which they will later be part of the releases.

Testing: CI should do (given it runs through representative builds), but I'm doing some extra tests (building out-of-tree examples) just to ensure that coverage is even better and make it even less likely to cause problems once a first full run is done on murdock.