### PR TITLE
rust: Update nightly version

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -325,9 +325,9 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-09-13 && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-09-25 && \
     rustup toolchain add stable && \
-    for T in nightly-2022-09-13 stable; do \
+    for T in nightly-2022-09-25 stable; do \
         rustup component add rust-src --toolchain \$T && \
         rustup target add i686-unknown-linux-gnu --toolchain \$T && \
         rustup target add riscv32imac-unknown-none-elf --toolchain \$T && \


### PR DESCRIPTION
This is what https://github.com/RIOT-OS/riotdocker/pull/204 should have been, but as that nightly build did not contain that day's rustc, the intended version was not installed.

---

I did tests back in #204, but they were about "do they existing things still work", not (what I couldn't test easily back then, as it'd have spanned many crates at once) "does it also have the intended effect of allowing stable use of all the new features".

This unblocks https://github.com/RIOT-OS/rust-riot-wrappers/pull/14, and would have made the rollback of https://github.com/RIOT-OS/RIOT/pull/18642#issuecomment-1257159506 unnecessary.