### PR TITLE
CI: Test Rust both with hello-world and gcoap example

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
           # action does only minimal fetching.
           (cd RIOT && git fetch origin master && git checkout FETCH_HEAD)
           make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest
+          make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest
           (cd RIOT && git switch -)
         env:
           BUILD_IN_DOCKER: 1


### PR DESCRIPTION
Build failures after https://github.com/RIOT-OS/riotdocker/pull/189 show that the test coverage is insufficient to catch C2Rust breakage; this mitigates it by building an example that pulls in much more code.