### PR TITLE
C2Rust updates / fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
           # action does only minimal fetching.
           (cd RIOT && git fetch origin master && git checkout FETCH_HEAD)
           make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest
+          make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest
           (cd RIOT && git switch -)
         env:
           BUILD_IN_DOCKER: 1

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -344,7 +344,7 @@ RUN \
 
 RUN \
     echo 'Installing C2Rust' >&2 && \
-    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --rev ed56c794230bbf5a0e417941e4778316d31ab114 && \
+    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --rev 7d88216756204553a44e2b1a39f840922229d5d6 && \
     echo 'Cleaning up root-owned crates.io cache' >&2 && \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -344,7 +344,7 @@ RUN \
 
 RUN \
     echo 'Installing C2Rust' >&2 && \
-    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --rev 7d88216756204553a44e2b1a39f840922229d5d6 && \
+    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/chrysn-pull-requests/c2rust --branch riscv-vector-types && \
     echo 'Cleaning up root-owned crates.io cache' >&2 && \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 


### PR DESCRIPTION
This branch is used for investigating failures encountered after merging #189, in which C2Rust errs internally. Upstream might already have solved it.

This builds on #209.