### PR TITLE
remove pic32-wifire from BOARDS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native pic32-wifire samr21-xpro"
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
 
       - name: GNU microbit qemu test
         run: >
@@ -149,7 +149,7 @@ jobs:
           # Not all of them are actually available; still using the "canonical"
           # list of representative boards above to keep this stable whil Rust
           # support expands
-          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native pic32-wifire samr21-xpro"
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
 
       - name: Run static tests
         run: |


### PR DESCRIPTION
MIPS support was removed: https://github.com/RIOT-OS/RIOT/pull/18562