### PR TITLE
rust: Only install stable toolchain

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -342,21 +342,18 @@ ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
     RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain nightly-2022-09-25 && \
-    rustup toolchain add stable && \
-    for T in nightly-2022-09-25 stable; do \
-        rustup component add rust-src --toolchain \$T && \
-        rustup target add i686-unknown-linux-gnu --toolchain \$T && \
-        rustup target add riscv32imac-unknown-none-elf --toolchain \$T && \
-        rustup target add thumbv7em-none-eabihf --toolchain \$T && \
-        rustup target add thumbv7em-none-eabi --toolchain \$T && \
-        rustup target add thumbv7m-none-eabi --toolchain \$T && \
-        rustup target add thumbv6m-none-eabi --toolchain \$T && \
-        rustup target add thumbv8m.main-none-eabihf --toolchain \$T && \
-        rustup target add thumbv8m.main-none-eabi --toolchain \$T && \
-        rustup target add thumbv8m.base-none-eabi --toolchain \$T && \
-        true; \
-    done"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
+    rustup component add rust-src && \
+    rustup target add i686-unknown-linux-gnu && \
+    rustup target add riscv32imac-unknown-none-elf && \
+    rustup target add thumbv7em-none-eabihf && \
+    rustup target add thumbv7em-none-eabi && \
+    rustup target add thumbv7m-none-eabi && \
+    rustup target add thumbv6m-none-eabi && \
+    rustup target add thumbv8m.main-none-eabihf && \
+    rustup target add thumbv8m.main-none-eabi && \
+    rustup target add thumbv8m.base-none-eabi && \
+    true"
 
 RUN \
     echo 'Installing C2Rust' >&2 && \


### PR DESCRIPTION
Closes: https://github.com/RIOT-OS/riotdocker/issues/208

As of Rust 1.65, there is no need for nightly versions of Rust for RIOT any more.

Currently, this will likely (i.e. unless the nightly selection script happens to manage the case of no nightlies by assigning stable instead) not build, and depends on https://github.com/RIOT-OS/RIOT/pull/18839 which switches away from nightlies. (See there for an overview of all lockstepping involved)