### PR TITLE
c2rust: Use released version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,12 @@ jobs:
           # that user, blocking downloads of own libraries.
           rm -rf ~/.cargo
           # Something left directories that break things
+          # A git clean wouldn't remove repositories
+          rm -rf RIOT/build
+          # These files can't be removed?
+          ls -ld tests/pkg_nanopb/bin/native/core_lib
+          ls -l tests/pkg_nanopb/bin/native/core_lib/atomic_c11.d
+          rm -rf tests/pkg_nanopb/bin/native/core_lib
           (cd RIOT && git clean -fxd)
           make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest
           make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
           # Some of the above are executed by root, creating ~/.cargo/git as
           # that user, blocking downloads of own libraries.
           rm -rf ~/.cargo
+          # Something left directories that break things
+          (cd RIOT && git clean -fxd)
           make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest
           make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest
         env:

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -344,7 +344,7 @@ RUN \
 
 RUN \
     echo 'Installing C2Rust' >&2 && \
-    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/chrysn-pull-requests/c2rust --branch riscv-vector-types && \
+    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --version 0.17.0 && \
     echo 'Cleaning up root-owned crates.io cache' >&2 && \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 


### PR DESCRIPTION
This reduces the dependency on a particular GitHub branch that I was already about to remove after https://github.com/immunant/c2rust/pull/693 was done.

Still marked as a draft as it depends on https://github.com/immunant/c2rust/issues/690 (but that has all its blockers gone already).