### PR TITLE
murdock_worker: add newer ccache (4.7.4)

### DIFF
--- a/murdock-worker/.gitattributes
+++ b/murdock-worker/.gitattributes
@@ -1,0 +1,1 @@
+*.tar.xz filter=lfs diff=lfs merge=lfs -text

--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -42,6 +42,9 @@ RUN tar -xvf /${CCACHE_TGZ} --strip-components=1 -C/usr/local/bin && rm /${CCACH
 # install murdock slave startup script
 COPY murdock_slave.sh /usr/bin/murdock_slave
 
+# create cache folder
+RUN mkdir -m777 /cache
+
 ENTRYPOINT ["/bin/bash", "/run.sh"]
 
 # By default, run a shell when no command is specified on the docker command line

--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -34,6 +34,11 @@ RUN wget https://raw.githubusercontent.com/kaspar030/git-cache/f76c3a5f0e15f08c2
         -O /usr/bin/git-cache \
         && chmod a+x /usr/bin/git-cache
 
+# install newer ccache package
+ARG CCACHE_TGZ=ccache-4.7.4-linux-x86_64.tar.xz
+COPY files/${CCACHE_TGZ}  /
+RUN tar -xvf /${CCACHE_TGZ} --strip-components=1 -C/usr/local/bin && rm /${CCACHE_TGZ}
+
 # install murdock slave startup script
 COPY murdock_slave.sh /usr/bin/murdock_slave
 

--- a/murdock-worker/files/ccache-4.7.4-linux-x86_64.tar.xz
+++ b/murdock-worker/files/ccache-4.7.4-linux-x86_64.tar.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b700cc10884f7faf615203241d34eba7ebe0723f38f6aeb77569a556ff37313
+size 978436


### PR DESCRIPTION
ccache version 4.7 adds the option to have a remote-only cache on secondary storage (e.g., **redis**).

I have a [branch](https://github.com/RIOT-OS/murdock-worker/pull/5) modifying the murdock worker docker-compose to add a redis instance for caching.

The ccache binary is the official binary release from https://ccache.dev/download.html.
(debians bookworm has a .dpkg, but that's not compatible to our Ubuntu's older libraries).

My hope is that a local redis scales better with larger caches, which have shown to stall builds when the cache is full and needs to be cleaned (@cgundogan remember the sawtoothing?). redis LRU is cheap.

Also, redis handles persistence (compared to tmpfs), which would **make reboots/restarts not loose all of ccache**.

Potentially, redis can be distributed, so e.g., the mobis could have a larger cache shared between them.

(I've piggibacked a commit creating `/cache` with rwx:all permissions, that's necessary to mount volumes so they're accessible by a non-root in-docker uid. otherwise, mounts default to root-only permissions.)