### PR TITLE
.github/workflows/build.yml: bump VERSION_TAG to `2023.01`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RIOT_BRANCH: '2022.10-branch'
-      VERSION_TAG: '2022.10'
+      VERSION_TAG: '2023.01'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:


### PR DESCRIPTION
... to be merged *after* 2022.10 has been released ...