### PR TITLE
Dockerfile: install libsdc++-arm-none-eabi-*

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -67,6 +67,10 @@ RUN \
         cython3 \
         gcc-multilib \
         gcc-arm-none-eabi \
+        libnewlib-arm-none-eabi \
+        libstdc++-arm-none-eabi-dev \
+        libstdc++-arm-none-eabi-newlib \
+        libstdc++-arm-none-eabi-picolibc \
         gcc-riscv64-unknown-elf \
         gcc-xtensa-lx106 \
         gdb \
@@ -75,7 +79,6 @@ RUN \
         libpcre3 \
         libtool \
         libsdl2-dev:i386 \
-        libnewlib-arm-none-eabi \
         m4 \
         parallel \
         protobuf-compiler \


### PR DESCRIPTION
As the title says...

Should fix https://ci.riot-os.org/results/8e1338abe27b407c8d2677e3a42ebb7e/output/builds/examples/riot_and_cpp/nrf52840dk:gnu.txt and similar failures.