### PR TITLE
.github: add step to build a cpp application

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,14 @@ jobs:
           # support expands
           BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
 
+      - name: C++ build test
+        run: |
+          make -C RIOT/tests/cpp11_condition_variable BUILDTEST_MAKE_REDIRECT='' buildtest
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
+          BOARDS: "esp32-wroom-32 hifive1b native samr21-xpro"
+
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \


### PR DESCRIPTION
This should prevent regressions when building application requiring cpp.