### PR TITLE
actions: remove obsolete switcharoo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,17 +132,8 @@ jobs:
           # Some of the above are executed by root, creating ~/.cargo/git as
           # that user, blocking downloads of own libraries.
           rm -rf ~/.cargo
-          # Once a release is out that can be built on stable, this switcharoo
-          # can be removed -- until then, each release of RIOT is only
-          # supported with the very Rust version that was the configured
-          # nightly it was released with; such is the nature of nightly.
-          #
-          # Note that `git switch master` does not work because the checkout
-          # action does only minimal fetching.
-          (cd RIOT && git fetch origin master && git checkout FETCH_HEAD)
           make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest
           make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest
-          (cd RIOT && git switch -)
         env:
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest


### PR DESCRIPTION
Copy of https://github.com/RIOT-OS/riotdocker/pull/182 that is rebased (actually, the logical removals are re-applied, but it's dressed with the same author and commit message).