### PR TITLE
Build extra riotdocker variant that includes nightly Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,31 @@ jobs:
           build-args: |
             DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
 
+      - name: Build riotbuild-rustnightly
+        uses: docker/build-push-action@v2
+        with:
+          context: ./riotbuild-rustnightly
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/riotbuild-rustnightly:latest
+            ${{ env.DOCKER_REGISTRY }}/riotbuild-rustnightly:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Rust build test on Rust nightly
+        run: |
+          # Some of the above are executed by root, creating ~/.cargo/git as
+          # that user, blocking downloads of own libraries.
+          rm -rf ~/.cargo
+          make -CRIOT/examples/rust-hello-world BUILDTEST_MAKE_REDIRECT='' buildtest CARGO_CHANNEL=nightly
+          make -CRIOT/examples/rust-gcoap BUILDTEST_MAKE_REDIRECT='' buildtest CARGO_CHANNEL=nightly
+        env:
+          BUILD_IN_DOCKER: 1
+          DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild-rustnightly:latest
+          # Not all of them are actually available; still using the "canonical"
+          # list of representative boards above to keep this stable whil Rust
+          # support expands
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
+
       - name: Login to DockerHub
         if: "${{ github.ref == 'refs/heads/master' }}"
         uses: docker/login-action@v1

--- a/riotbuild-rustnightly/Dockerfile
+++ b/riotbuild-rustnightly/Dockerfile
@@ -1,0 +1,20 @@
+#
+# Dockerfile for RIOT build environments with extra Rust nightly
+#
+# The resulting image will be based on riotdocker, but also install the current
+# RIOT nightly versions to enable easy building of applications that need
+# nightly.
+
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/riotbuild:latest
+
+# For the value of CARGO_HOME, see the comments in riotbuild's Dockerfile.
+RUN \
+    set -ex; \
+    export CARGO_HOME=/opt/rustup/.cargo; \
+    rustup toolchain add nightly; \
+    for target in $(rustup target list --installed); \
+    do \
+        rustup target add $target --toolchain nightly; \
+    done; \
+    rustup default nightly


### PR DESCRIPTION
After https://github.com/RIOT-OS/riotdocker/pull/214 is merged (which, on its own, is not blocked any more), users who used riotdocker but also needed nightly features are in a bit of a pickle: There is no image any more with which they can just dockerbuild their applications in.

As this is not part of the critical CI tests, and the features this'd be used with are usually rather mature, I see no immediate need to pin the nightly version (which also means that, if we want to go this way, I may occasionally press the "master: re-run" button as the need arises).

I'm not 100% sure the tests that are added for this part of the GitHub actions really take -- I'm still investigating whether CARGO_CHANNEL is correctly passed through run-in-docker (but maybe that's unwarranted anyway because https://github.com/RIOT-OS/RIOT/pull/18840 is a next step and would remove that variable altogether in favor of just using cargo's mechanisms, now that regular RIOT tests don't need to interfere with it any more).

Due disclaimer / more precise motivation: I expect to be the next user of these myself. There are upcoming abstractions in riot-wrappers that'd depend on nightly-only crates. While such features would not be covered by what is tested when RIOT's own riot-wrappers version is updated (for RIOT's tests are built on riotbuild, and with stable only, so the relevant features of riot-wrappers would just not be enabled). But riot-wrappers itself runs its tests (esp. native) on GitHub actions, and for these it'd be quite handy to have a riotdocker image with nightly available.

---

As for reviewing, the biggest question is whether we want to have this built and maintained in here. I think it fits, especially as it can re-use all the established secrets and uploading infrastructure, and because it ensures that the images are in sync with the base image (so that whoever switches from stable to nightly just needs to download a small Docker delta image).