### PR TITLE
riotbuild: bump esp32x toolchains to gcc version 12.2

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -204,19 +204,19 @@ RUN echo 'Installing ESP8266 toolchain' >&2 && \
 ENV PATH $PATH:/opt/esp/xtensa-esp8266-elf/bin
 ENV ESP8266_RTOS_SDK_DIR /opt/esp/ESP8266_RTOS_SDK
 
-# Install ESP32 toolchain in /opt/esp (289 MB)
-ARG ESP32_GCC_RELEASE="esp-2021r2-patch3"
-ARG ESP32_GCC_VERSION="gcc8_4_0"
+# Install ESP32 toolchain in /opt/esp (338 MB)
+ARG ESP32_GCC_RELEASE="esp-12.2.0_20230208"
+ARG ESP32_GCC_VERSION="12.2.0_20230208"
 ARG ESP32_GCC_REPO=https://github.com/espressif/crosstool-NG/releases/download
-ARG ESP32_GCC_FILE=xtensa-esp32-elf-${ESP32_GCC_VERSION}-${ESP32_GCC_RELEASE}-linux-amd64.tar.gz
+ARG ESP32_GCC_FILE=xtensa-esp32-elf-${ESP32_GCC_VERSION}-x86_64-linux-gnu.tar.xz
 ARG ESP32_GCC_URL=${ESP32_GCC_REPO}/${ESP32_GCC_RELEASE}/${ESP32_GCC_FILE}
 
 RUN echo 'Installing ESP32 toolchain' >&2 && \
-    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xz && \
+    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xJ && \
     pip install --no-cache-dir pyserial
 ENV PATH $PATH:/opt/esp/xtensa-esp32-elf/bin
 
-# Install ESP32 QEMU in /opt/esp (89 MB)
+# Install ESP32 QEMU in /opt/esp (130 MB)
 ARG ESP32_QEMU_VERSION="esp-develop-20220203"
 ARG ESP32_QEMU_REPO=https://github.com/espressif/qemu/releases/download
 ARG ESP32_QEMU_FILE=qemu-${ESP32_QEMU_VERSION}.tar.bz2
@@ -226,32 +226,48 @@ RUN echo 'Installing ESP32 QEMU' >&2 && \
     curl -L ${ESP32_QEMU_URL} | tar -C /opt/esp -xj
 ENV PATH $PATH:/opt/esp/qemu/bin
 
-# Install ESP32-C3 toolchain in /opt/esp (344 MB)
-ARG ESP32_GCC_FILE=riscv32-esp-elf-${ESP32_GCC_VERSION}-${ESP32_GCC_RELEASE}-linux-amd64.tar.gz
+# Install ESP32-C3 toolchain in /opt/esp (859 MB)
+ARG ESP32_GCC_FILE=riscv32-esp-elf-${ESP32_GCC_VERSION}-x86_64-linux-gnu.tar.xz
 ARG ESP32_GCC_URL=${ESP32_GCC_REPO}/${ESP32_GCC_RELEASE}/${ESP32_GCC_FILE}
 
 RUN echo 'Installing ESP32-C3 toolchain' >&2 && \
-    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xz && \
-    pip install --no-cache-dir pyserial
+    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xJ
 ENV PATH $PATH:/opt/esp/riscv32-esp-elf/bin
 
-# Install ESP32-S2 toolchain in /opt/esp (290 MB)
-ARG ESP32_GCC_FILE=xtensa-esp32s2-elf-${ESP32_GCC_VERSION}-${ESP32_GCC_RELEASE}-linux-amd64.tar.gz
+# Install ESP32-S2 toolchain in /opt/esp (340 MB)
+ARG ESP32_GCC_FILE=xtensa-esp32s2-elf-${ESP32_GCC_VERSION}-x86_64-linux-gnu.tar.xz
 ARG ESP32_GCC_URL=${ESP32_GCC_REPO}/${ESP32_GCC_RELEASE}/${ESP32_GCC_FILE}
 
 RUN echo 'Installing ESP32-S2 toolchain' >&2 && \
-    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xz && \
-    pip install --no-cache-dir pyserial
+    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xJ
 ENV PATH $PATH:/opt/esp/xtensa-esp32s2-elf/bin
 
-# Install ESP32-S3 toolchain in /opt/esp (292 MB)
-ARG ESP32_GCC_FILE=xtensa-esp32s3-elf-${ESP32_GCC_VERSION}-${ESP32_GCC_RELEASE}-linux-amd64.tar.gz
+# Install ESP32-S3 toolchain in /opt/esp (341 MB)
+ARG ESP32_GCC_FILE=xtensa-esp32s3-elf-${ESP32_GCC_VERSION}-x86_64-linux-gnu.tar.xz
 ARG ESP32_GCC_URL=${ESP32_GCC_REPO}/${ESP32_GCC_RELEASE}/${ESP32_GCC_FILE}
 
 RUN echo 'Installing ESP32-S3 toolchain' >&2 && \
-    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xz && \
-    pip install --no-cache-dir pyserial
+    curl -L ${ESP32_GCC_URL} | tar -C /opt/esp -xJ
 ENV PATH $PATH:/opt/esp/xtensa-esp32s3-elf/bin
+
+# Install GDB for Xtensa base ESP32 x SoCs in /opt/esp (94 MB)
+ARG ESP32_GDB_VERSION=12.1_20221002
+ARG ESP32_GDB_REPO=https://github.com/espressif/binutils-gdb/releases/download
+ARG ESP32_GDB_REPO_DIR=esp-gdb-v${ESP32_GDB_VERSION}
+ARG ESP32_GDB_FILE=xtensa-esp-elf-gdb-${ESP32_GDB_VERSION}-x86_64-linux-gnu.tar.gz
+ARG ESP32_GDB_URL=${ESP32_GDB_REPO}/${ESP32_GDB_REPO_DIR}/${ESP32_GDB_FILE}
+
+RUN echo 'Installing GDB for Xtensa based ESP32x SoCs' >&2 && \
+    curl -L ${ESP32_GDB_URL} | tar -C /opt/esp -xz
+ENV PATH $PATH:/opt/esp/xtensa-esp-elf-gdb/bin
+
+# Install GDB for RISC-V based ESP32 SoCs in /opt/esp (93 MB)
+ARG ESP32_GDB_FILE=riscv32-esp-elf-gdb-${ESP32_GDB_VERSION}-x86_64-linux-gnu.tar.gz
+ARG ESP32_GDB_URL=${ESP32_GDB_REPO}/${ESP32_GDB_REPO_DIR}/${ESP32_GDB_FILE}
+
+RUN echo 'Installing GDB for RISC-V based ESP32x SoCs' >&2 && \
+    curl -L ${ESP32_GDB_URL} | tar -C /opt/esp -xz
+ENV PATH $PATH:/opt/esp/riscv32-esp-elf-gdb/bin
 
 ARG PICOLIBC_REPO=https://github.com/keith-packard/picolibc
 ARG PICOLIBC_TAG=1.4.6


### PR DESCRIPTION
This PR upgrades ESP32x toolchains to GCC version 12.2. Since ESP-IDF 5.1 requires this compiler version, this PR has to be merged before we can start with RIOT upgrade to ESP-IDF 5.1.

This PR depends on https://github.com/RIOT-OS/RIOT/pull/19450.