### PR TITLE
CI: bump RIOT_BRANCH to 2023.04-branch and VERSION_TAG to 2023.07

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2022.10-branch'
-      VERSION_TAG: '2023.01'
+      RIOT_BRANCH: '2023.04-branch'
+      VERSION_TAG: '2023.07'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:


### PR DESCRIPTION
With 2023.04 out, it's time to bump riotdocker's base branch.