### PR TITLE
add ld-memory

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -366,7 +366,7 @@ RUN \
 
 # get ld-memory from pre-built containers (ld-memory is used for on-the-fly
 # .ld linker script generation)
-COPY --from=kaspar030/ld-memory:0.2 /ld-memory /usr/bin/ld-memory
+COPY --from=kaspar030/ld-memory:0.2.7 /ld-memory /usr/bin/ld-memory
 
 # get Dockerfile version from build args
 ARG RIOTBUILD_VERSION=unknown


### PR DESCRIPTION
This adds [ld-memory](https://github.com/kaspar030/ld-memory), a utility I wrote that creates GNU ld MEMORY sections from command line parameters.

Needed for https://github.com/RIOT-OS/RIOT/pull/19692.

(adds ~800kB to the image)