### PR TITLE
Explicitly name registries to enable building on podman

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -3,7 +3,7 @@
 #
 # the resulting image is being used in RIOT's CI (Murdock)
 
-ARG DOCKER_REGISTRY="riot"
+ARG DOCKER_REGISTRY="docker.io/riot"
 FROM ${DOCKER_REGISTRY}/riotbuild:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -19,7 +19,7 @@
 # Usage:
 # 1. cd to riot root
 # 2. # docker run -i -t -u $UID -v $(pwd):/data/riotbuild riotbuild ./dist/tools/compile_test/compile_test.py
-ARG DOCKER_REGISTRY="riot"
+ARG DOCKER_REGISTRY="docker.io/riot"
 FROM ${DOCKER_REGISTRY}/static-test-tools:latest
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -1,4 +1,4 @@
-ARG DOCKER_REGISTRY="riot"
+ARG DOCKER_REGISTRY="docker.io/riot"
 FROM ${DOCKER_REGISTRY}/riotdocker-base:latest
 
 LABEL maintainer="alexandre.abadie@inria.fr"


### PR DESCRIPTION
Closes: https://github.com/RIOT-OS/riotdocker/issues/223

It's a fairly trivial change; if docker consistently works in where it takes fully qualified names, it should just work. (I suppose that means that all is fine if CI says go).

<del>We've also had some build failures on master recently; this PR doubles as a way to flush them out without triggering a possibly unexpected image change mid-release.</del> (that was fixed in #234)