### PR TITLE
Pin down scipy version

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -11,6 +11,7 @@ colorama>=0.4.0
 cryptography==3.3.2
 scapy>=2.4.3
 protobuf==3.18.3
+scipy == 1.10.1            # needed by scikit-learn, but newer ones fail with jammy's cython
 scikit-learn==0.22.1
 joblib==1.2.0
 emlearn==0.10.1


### PR DESCRIPTION
Newer versions cause build failures because they expect a newer cython than is provided in jammy; they'd show errors like:

```
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      ctypedef float s                                                                                                                             ctypedef double d                                                                                                                            ctypedef float complex c
      ctypedef double complex z
      cdef void caxpy(int *n, c *ca, c *cx, int *incx, c *cy, int *incy) noexcept nogil
                                                                        ^
      ------------------------------------------------------------

      /usr/local/lib/python3.10/dist-packages/scipy/linalg/cython_blas.pxd:20:67: Syntax error in C variable declaration
```

Let's hope this allows building again -- if not, we have multiple bitrots to combat.