### PR TITLE
murdock-worker: bump dwq to 0.0.60

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -20,7 +20,7 @@ RUN \
         apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install dwq (disque work queue)
-RUN pip3 install dwq==0.0.56
+RUN pip3 install dwq==0.0.60
 
 # install hiredis -- not required directly, but redis (from dwq) will spew
 # warnings otherwise that break things somewhere further down the line.


### PR DESCRIPTION
This bumps dwq to the latest version.

I'm running this on beast right now.

- [x] [test on ci-staging](https://ci-staging.riot-os.org/details/aef6af2474544ec9872d419c3ee7c7dd/stats) was successful
- [x] [ci.riot-os.org](https://ci.riot-os.org/details/091eab9404254c74aea0fcc5c28fe044/stats)