### PR TITLE
riotbuild: add laze 0.1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,11 @@ jobs:
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
           BOARDS: "esp32-wroom-32 hifive1b native samr21-xpro"
 
+      - name: laze test
+        run: |
+          docker run --rm -t ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
+            laze --version
+
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -361,6 +361,9 @@ RUN \
     echo 'Cleaning up root-owned crates.io cache' >&2 && \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 
+# get laze binary
+COPY --from=kaspar030/laze:0.1.20-jammy /laze /usr/bin/laze
+
 # get Dockerfile version from build args
 ARG RIOTBUILD_VERSION=unknown
 ENV RIOTBUILD_VERSION $RIOTBUILD_VERSION


### PR DESCRIPTION
This PR adds the current development version of the laze build system.
While we're not using it currently, having it in the containers makes experimenting with a possible migration much easier.
The binary is copied from an upstream provided docker container, and clocks in at slightly below 6mb.