### PR TITLE
riotbuild: add libsdl2-dev:amd64

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -71,6 +71,7 @@ RUN \
         libffi-dev \
         libpcre3 \
         libtool \
+        libsdl2-dev \
         libsdl2-dev:i386 \
         m4 \
         ninja-build \


### PR DESCRIPTION
Adds the 64-bit version of libsdl2-dev required for the 64-bit version of native.
Needed in RIOT-OS/RIOT#20335

libsdl2-dev has quite a few dependencies and **adds about 190MB to the image**.
If this is too much, I could also blacklist `tests_lvgl` and `tests_lvgl_touch` for the CI.