### PR TITLE
murdock-worker: bump git-cache-rs to 0.1.5

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3 install hiredis
 RUN pip3 install click
 
 # get git-cache-rs binary
-COPY --from=ghcr.io/kaspar030/git-cache:0.1.3-jammy /git-cache /usr/bin/git-cache
+COPY --from=ghcr.io/kaspar030/git-cache:0.1.5-jammy /git-cache /usr/bin/git-cache
 ENV GIT_CACHE_RS /usr/bin/git-cache
 
 # install newer ccache package


### PR DESCRIPTION
When the initial `git cache clone` would have a commit specified (`--commit HASH`), and would trigger the initial clone into the cache directory, the final "checkout HASH" was skipped.

This caused the first dwq worker thread to checkout a branch to fail every job with `./.murdock: not found`.

https://github.com/kaspar030/git-cache-rs/compare/0.1.3...0.1.5
