### PR TITLE
riotbuild/requirements: bump emlearn and related dependencies versions

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -12,9 +12,9 @@ cryptography==3.3.2
 scapy>=2.4.3
 protobuf==3.18.3
 scipy == 1.10.1            # needed by scikit-learn, but newer ones fail with jammy's cython
-scikit-learn==0.22.1
-joblib==1.2.0
-emlearn==0.10.1
+scikit-learn==1.4.0
+joblib==1.3.2
+emlearn==0.17.1
 jinja2==2.11.3
 riotctrl[rapidjson]>=0.4.0
 pyhsslms>=1.0.0


### PR DESCRIPTION
Bump versions of emlearn, joblib and most important scikit-learn so that https://github.com/RIOT-OS/RIOT/pull/20347 should pass the CI