### PR TITLE
ci: bump RIOT_BRANCH to `2024.01-branch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2023.10-branch'
+      RIOT_BRANCH: '2024.01-branch'
       VERSION_TAG: '2024.01'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 


### PR DESCRIPTION
This should fix #242 b/c 2024.01-branch includes https://github.com/RIOT-OS/rust-riot-sys/pull/36.