### PR TITLE
static-test-tools: add PyYAML to requirements.txt

### DIFF
--- a/static-test-tools/requirements.txt
+++ b/static-test-tools/requirements.txt
@@ -1,3 +1,4 @@
 # Required python libraries for static tests
 flake8==3.8.4
 codespell>=1.17.1
+PyYAML==6.0.1


### PR DESCRIPTION
This should allow parsing YAML files from Python as part of `static-tests` in the CI.