### PR TITLE
riotbuild: Install python3-venv

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -78,6 +78,7 @@ RUN \
         protobuf-compiler \
         python2 \
         python3-setuptools \
+        python3-venv \
         python3-wheel \
         p7zip \
         qemu-system-arm \


### PR DESCRIPTION
We don't have a user for it yet in RIOT, but I'm working on a tool in https://github.com/RIOT-OS/RIOT/pull/20395 that'd make good use of it. (Essentially it's installing requirements.txt of local tools into venvs on demand, removing the need to have all modules used anywhere as dependencies of RIOT-as-a-whole. It'd still be preferable if the modules were avaialble in riotdocker, but the flexibility makes PRs easier without going through riotdocker first for every single thing.)

Note that you *can* do `python3 -m venv` in the container already, but without the python3-venv Debian package, it can't set up a pip inside venv, and usually that's the very reason why one would use a venv in the first place (and the tool mentioned above relies on it).