### PR TITLE
static: Add cargo

### DIFF
--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     apt-get update && \
     echo 'Installing static test tools' >&2 && \
     apt-get -y --no-install-recommends install \
+        cargo \
         coccinelle \
         cppcheck \
         doxygen \


### PR DESCRIPTION
This is needed for the static tests introduced in [20886]; no need for nightly or target specific tools.

[20886]: https://github.com/RIOT-OS/RIOT/pull/20886

This increases the size reported by `docker image list` from 781MB to 1.17GB.