### PR TITLE
Move minimal Rust from riotbuild to static-test-tools

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -63,7 +63,6 @@ RUN \
         ca-certificates \
         ccache \
         cmake \
-        curl \
         cython3 \
         gcc-multilib \
         gdb \
@@ -324,27 +323,15 @@ RUN echo 'Installing python3 packages' >&2 \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 
-# While sourcing ~/.cargo/env later would have the right short-term effect,
-# we'd still need to set the right path even later when HOME is
-# /data/riotbuild -- so setting it right away.
-ENV PATH ${PATH}:/opt/rustup/.cargo/bin
-# Install nightly Rust via rustup; this is needed for Rust-on-RIOT builds and
-# contains all CARGO_TARGETs currently recognized for RIOT targets.
+# Add Rust components needed for building, adding to installation from static-test-tools
 #
-# *_HOMEs moved to /opt to make them world readable. RUSTUP_HOME is set
-# persistently in case someone in their image wants to do a quick `sudo rustup
-# toolchain add` or similar; CARGO_HOME is not because the user will need to
-# write there, and all rustup does here is to place some binaries that later
-# fan out to RUSTUP_HOME anyway.
+# See static-test-tools/Dockerfile for why which variables are set how.
 #
 # Components: rust-src is needed to run `-Z build-std=core`, which in turn is
 # needed on AVR (which thus doesn't need the avr-unknown-gnu-atmega328 target;
 # being able to build core might be useful for other targets as well).
-ENV RUSTUP_HOME /opt/rustup/.rustup
 RUN \
-    RUSTUP_HOME=/opt/rustup/.rustup \
     CARGO_HOME=/opt/rustup/.cargo sh -c "\
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -15,6 +15,7 @@ RUN \
     apt-get -y --no-install-recommends install \
         coccinelle \
         cppcheck \
+        curl \
         doxygen \
         graphviz \
         less \
@@ -35,3 +36,27 @@ RUN echo 'Installing python3 packages' >&2 && \
 
 # Install uncrustify
 COPY --from=ghcr.io/kaspar030/uncrustify-builder:latest /usr/bin/uncrustify /usr/bin/uncrustify
+
+# Rust base installation
+
+# While sourcing ~/.cargo/env later would have the right short-term effect,
+# we'd still need to set the right path even later when HOME is
+# /data/riotbuild -- so setting it right away.
+ENV PATH ${PATH}:/opt/rustup/.cargo/bin
+
+# Install Rust via rustup; this is needed for Rust-on-RIOT builds and contains
+# all CARGO_TARGETs currently recognized for RIOT targets.
+#
+# *_HOMEs moved to /opt to make them world readable. RUSTUP_HOME is set
+# persistently in case someone in their image wants to do a quick `sudo rustup
+# toolchain add` or similar; CARGO_HOME is not because the user will need to
+# write there, and all rustup does here is to place some binaries that later
+# fan out to RUSTUP_HOME anyway.
+#
+# Components: fmt is needed for the static test tools as those do `cargo fmt`
+# checks. More are added for riotbuild.
+ENV RUSTUP_HOME /opt/rustup/.rustup
+RUN \
+    CARGO_HOME=/opt/rustup/.cargo sh -c "\
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
+    rustup component add rustfmt"


### PR DESCRIPTION
This is the second attempt to fix https://github.com/RIOT-OS/RIOT/pull/20886 by adding Rust earlier in the process, after https://github.com/RIOT-OS/riotdocker/pull/253 taught me that riotbuild is built from static-test-tools.