### PR TITLE
ci: bump RIOT_BRANCH and VERSION_TAG to 2025.01-branch and 2025.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2024.01-branch'
-      VERSION_TAG: '2024.01'
+      RIOT_BRANCH: '2025.01-branch'
+      VERSION_TAG: '2025.04'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:


### PR DESCRIPTION
Regular update like https://github.com/RIOT-OS/riotdocker/pull/236 -- with this, we can start building containers that don't claim to be building for the older versions any more, which is one step in preparing for future releases (eg. where with https://github.com/RIOT-OS/riotdocker/pull/256 there will be changed checkout folders).