### PR TITLE
Add tiny and small build images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,124 @@ jobs:
         with:
           driver: docker
 
+      - name: Build tinybuild-apks
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-apks
+          tags: |
+            tinybuild-apks:latest
+            tinybuild-apks:${{ env.VERSION_TAG }}
+
+      - name: Build tinybuild-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-base
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-base:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-base:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build smallbuild-base
+        uses: docker/build-push-action@v2
+        with:
+          context: ./smallbuild-base
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-base:latest
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-base:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build tinybuild-arm
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-arm
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-arm:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-arm:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build smallbuild-arm
+        uses: docker/build-push-action@v2
+        with:
+          context: ./smallbuild-arm
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-arm:latest
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-arm:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build tinybuild-avr
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-avr
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-avr:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-avr:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build tinybuild-msp430
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-msp430
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-msp430:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-msp430:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build smallbuild-msp430
+        uses: docker/build-push-action@v2
+        with:
+          context: ./smallbuild-msp430
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:latest
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build tinybuild-native64
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-native64
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-native64:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-native64:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build smallbuild-native64
+        uses: docker/build-push-action@v2
+        with:
+          context: ./smallbuild-native64
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-native64:latest
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-native64:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build tinybuild-risc-v
+        uses: docker/build-push-action@v2
+        with:
+          context: ./tinybuild-risc-v
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-risc-v:latest
+            ${{ env.DOCKER_REGISTRY }}/tinybuild-risc-v:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
+      - name: Build smallbuild-risc-v
+        uses: docker/build-push-action@v2
+        with:
+          context: ./smallbuild-risc-v
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-risc-v:latest
+            ${{ env.DOCKER_REGISTRY }}/smallbuild-risc-v:${{ env.VERSION_TAG }}
+          build-args: |
+            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
+
       - name: Build riotdocker-base
         uses: docker/build-push-action@v2
         with:
@@ -190,6 +308,28 @@ jobs:
       - name: Push Images
         if: "${{ github.ref == 'refs/heads/master' }}"
         run: |
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-base:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-base:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-base:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-base:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-arm:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-arm:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-arm:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-arm:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-avr:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-avr:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-msp430:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-msp430:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-native64:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-native64:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-native64:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-native64:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-risc-v:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/tinybuild-risc-v:${{ env.VERSION_TAG }}
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-risc-v:latest
+          docker image push ${{ env.DOCKER_REGISTRY }}/smallbuild-risc-v:${{ env.VERSION_TAG }}
           docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
           docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.VERSION_TAG }}
           docker image push ${{ env.DOCKER_REGISTRY }}/static-test-tools:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,16 +120,6 @@ jobs:
           build-args: |
             DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
 
-      - name: Build smallbuild-msp430
-        uses: docker/build-push-action@v2
-        with:
-          context: ./smallbuild-msp430
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:latest
-            ${{ env.DOCKER_REGISTRY }}/smallbuild-msp430:${{ env.VERSION_TAG }}
-          build-args: |
-            DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
-
       - name: Build tinybuild-native64
         uses: docker/build-push-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # riotbuild
+
 Dockerfiles for creating build environment for building RIOT projects.
+
+# `tinybuild-*`` and `smallbuild-*`` Containers
+
+Compared to the full fledges `riotbuild` container, the `smallbuild-*`
+containers only a single architecture. The `tinybuild-*` are trimmed down
+even more by only supporting C code by dropping the C++ and rust toolchains.
+(Except for AVR, which always provides C++ support.)
+
+## Platform Support
+
+| Image                 | Size      | `native32` | `native64` | ARM7 Boards | Cortex M Boards | RISC-V Boards | AVR8 Boards | MSP430 Boards | ESP* Xtensa Boards | ESP* RISC-V Boards |
+| --------------------- | --------- | ---------- | ---------- | ----------- | --------------- | ------------- | ----------- | ------------- | ------------------ | ------------------ |
+| `riotbuild`           | ~ 13.5 GB | ✔          | ✔          | ✔           | ✔               | ✔             | ✔           | ✔             | ✔                  | ✔                  |
+| `smallbuild-arm`      | ~ 4.3 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
+| `smallbuild-msp430`   | ~ 0.5 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
+| `smallbuild-native64` | ~ 2.4 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
+| `smallbuild-risc-v`   | ~ 3.3 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
+| `tinybuild-arm`       | ~ 1.2 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
+| `tinybuild-avr`       | ~ 0.4 GB  |            |            |             |                 |               | ✔           |               |                    |                    |
+| `tinybuild-msp430`    | ~ 0.4 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
+| `tinybuild-native64`  | ~ 0.3 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
+| `tinybuild-risc-v`    | ~ 1.1 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
+
+## Language Support
+
+| Image                 | Size      | C   | C++   | rust  |
+| --------------------- | --------- | --- | ----- | ----- |
+| `riotbuild`           | ~ 13.5 GB | ✔   | ✔ [1] | ✔ [2] |
+| `smallbuild-arm`      | ~ 4.3 GB  | ✔   | ✔     | ✔     |
+| `smallbuild-msp430`   | ~ 0.5 GB  | ✔   | ✔     |       |
+| `smallbuild-native64` | ~ 2.4 GB  | ✔   | ✔     | ✔     |
+| `smallbuild-risc-v`   | ~ 3.3 GB  | ✔   | ✔     | ✔     |
+| `tinybuild-arm`       | ~ 1.2 GB  | ✔   |       |       |
+| `tinybuild-avr`       | ~ 0.4 GB  | ✔   | ✔ [1] |       |
+| `tinybuild-msp430`    | ~ 0.4 GB  | ✔   |       |       |
+| `tinybuild-native64`  | ~ 0.3 GB  | ✔   |       |       |
+| `tinybuild-risc-v`    | ~ 1.1 GB  | ✔   |       |       |
+
+1. On AVR, C++ is supported but libstdc++ is not
+2. rust is not provided for some architectures

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ even more by only supporting C code by dropping the C++ and rust toolchains.
 
 ## Platform Support
 
-| Image                 | Size      | `native32` | `native64` | ARM7 Boards | Cortex M Boards | RISC-V Boards | AVR8 Boards | MSP430 Boards | ESP* Xtensa Boards | ESP* RISC-V Boards |
-| --------------------- | --------- | ---------- | ---------- | ----------- | --------------- | ------------- | ----------- | ------------- | ------------------ | ------------------ |
-| `riotbuild`           | ~ 13.5 GB | ✔          | ✔          | ✔           | ✔               | ✔             | ✔           | ✔             | ✔                  | ✔                  |
-| `smallbuild-arm`      | ~ 4.3 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
-| `smallbuild-msp430`   | ~ 0.5 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
-| `smallbuild-native64` | ~ 2.4 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
-| `smallbuild-risc-v`   | ~ 3.3 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
-| `tinybuild-arm`       | ~ 1.2 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
-| `tinybuild-avr`       | ~ 0.4 GB  |            |            |             |                 |               | ✔           |               |                    |                    |
-| `tinybuild-msp430`    | ~ 0.4 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
-| `tinybuild-native64`  | ~ 0.3 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
-| `tinybuild-risc-v`    | ~ 1.1 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
+| Image                   | Size      | `native32` | `native64` | ARM7 Boards | Cortex M Boards | RISC-V Boards | AVR8 Boards | MSP430 Boards | ESP* Xtensa Boards | ESP* RISC-V Boards |
+| ----------------------- | --------- | ---------- | ---------- | ----------- | --------------- | ------------- | ----------- | ------------- | ------------------ | ------------------ |
+| `riotbuild`             | ~ 13.5 GB | ✔          | ✔          | ✔           | ✔               | ✔             | ✔           | ✔             | ✔                  | ✔                  |
+| `smallbuild-arm`        | ~ 4.3 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
+| `smallbuild-msp430` (*) | ~ 0.5 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
+| `smallbuild-native64`   | ~ 2.4 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
+| `smallbuild-risc-v`     | ~ 3.3 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
+| `tinybuild-arm`         | ~ 1.2 GB  |            |            | ✔           | ✔               |               |             |               |                    |                    |
+| `tinybuild-avr`         | ~ 0.4 GB  |            |            |             |                 |               | ✔           |               |                    |                    |
+| `tinybuild-msp430`      | ~ 0.4 GB  |            |            |             |                 |               |             | ✔             |                    |                    |
+| `tinybuild-native64`    | ~ 0.3 GB  |            | ✔          |             |                 |               |             |               |                    |                    |
+| `tinybuild-risc-v`      | ~ 1.1 GB  |            |            |             |                 | ✔             |             |               |                    |                    |
+- (*) Current g++ does not build for MSP430, so there is no `smallbuild-msp430`
 
 ## Language Support
 

--- a/smallbuild-arm/Dockerfile
+++ b/smallbuild-arm/Dockerfile
@@ -1,0 +1,20 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/smallbuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        newlib-arm-none-eabi \
+        picolibc-arm-none-eabi \
+        g++-arm-none-eabi  && \
+    CARGO_HOME=/opt/rustup/.cargo sh -c "\
+        rustup target add thumbv7em-none-eabihf && \
+        rustup target add thumbv7em-none-eabi && \
+        rustup target add thumbv7m-none-eabi && \
+        rustup target add thumbv6m-none-eabi && \
+        rustup target add thumbv8m.main-none-eabihf && \
+        rustup target add thumbv8m.main-none-eabi && \
+        rustup target add thumbv8m.base-none-eabi"

--- a/smallbuild-base/Dockerfile
+++ b/smallbuild-base/Dockerfile
@@ -1,0 +1,18 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+ENV \
+    RUSTUP_HOME=/opt/rustup/.rustup \
+    PATH=${PATH}:/opt/rustup/.cargo/bin
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        rustup \
+        musl-dev \
+        clang-libclang \
+        c2rust && \
+    CARGO_HOME=/opt/rustup/.cargo rustup-init -y && \
+    cp /tinybuild-apks/rustc /opt/rustup/.cargo/bin

--- a/smallbuild-msp430/Dockerfile
+++ b/smallbuild-msp430/Dockerfile
@@ -1,0 +1,10 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-msp430:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        g++-msp430-elf

--- a/smallbuild-native64/Dockerfile
+++ b/smallbuild-native64/Dockerfile
@@ -1,0 +1,14 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/smallbuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        libucontext-dev@riotapks \
+        gcc \
+        musl-dev \
+        linux-headers && \
+    CARGO_HOME=/opt/rustup/.cargo rustup target add x86_64-unknown-linux-gnu

--- a/smallbuild-risc-v/Dockerfile
+++ b/smallbuild-risc-v/Dockerfile
@@ -1,0 +1,13 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/smallbuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        newlib-riscv-none-elf \
+        picolibc-riscv-none-elf \
+        g++-riscv-none-elf && \
+    CARGO_HOME=/opt/rustup/.cargo rustup target add riscv32imac-unknown-none-elf

--- a/tinybuild-apks/Dockerfile
+++ b/tinybuild-apks/Dockerfile
@@ -1,0 +1,35 @@
+# This docker is not intended to be run, it is rather an intermediate step
+# to create custom packages for consumption by other docker containers
+FROM alpine:latest
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+# install all package needed for building apks
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    apk add \
+        alpine-sdk \
+        doas \
+        findutils \
+        lua-aports
+
+# setup a user and create keys needed to sign apks
+RUN \
+    adduser -D builder && \
+    adduser builder abuild && \
+    echo "permit nopass builder as root" > /etc/doas.conf && \
+    su builder -c 'abuild-keygen -ian' && \
+    mkdir /output && \
+    chmod 777 /output -R && \
+    su builder -c 'cp ~/.abuild/*.rsa.pub /output/'
+
+# create an output directory and build all packages from the aports folder
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/var/aports,source=aports \
+    su builder -c 'mkdir -p ~/aports && cp /var/aports ~/aports/riotapks -r' && \
+    su builder -c 'buildrepo -d /output riotapks'
+
+# built custom binaries that are not packaged
+RUN \
+    --mount=type=bind,target=/var/src,source=src \
+    gcc -Os -Wall -Werror -Wpedantic -o /output/rustc /var/src/fixed-rustc.c

--- a/tinybuild-apks/aports/libucontext/0001-fix-header-install-dir.patch
+++ b/tinybuild-apks/aports/libucontext/0001-fix-header-install-dir.patch
@@ -1,0 +1,15 @@
+Drop the paths from LIBUCONTEXT_HEADERS when installing, so that `libucontext.h`
+will find `bits.h`.
+--- a/Makefile	2024-10-07 03:37:08.000000000 +0200
++++ b/Makefile	2025-03-21 21:16:16.761054357 +0100
+@@ -215,8 +215,8 @@ install: all
+ 	install -D -m664 ${LIBUCONTEXT_STATIC_NAME} ${DESTDIR}${LIBUCONTEXT_STATIC_PATH}
+ 	ln -sf ${LIBUCONTEXT_SONAME} ${DESTDIR}${shared_libdir}/${LIBUCONTEXT_NAME}
+ 	for i in ${LIBUCONTEXT_HEADERS}; do \
+-		destfn=$$(echo $$i | sed s:include/::g); \
+-		install -D -m644 $$i ${DESTDIR}${includedir}/$$destfn; \
++		destfn=$$(basename $$i); \
++		install -D -m644 $$i ${DESTDIR}${includedir}/$(basename $(LIBUCONTEXT_NAME))/$$destfn; \
+ 	done
+ 	install -D -m644 ${LIBUCONTEXT_PC} ${DESTDIR}${pkgconfigdir}/${LIBUCONTEXT_PC}
+ 	if [ -n "${LIBUCONTEXT_POSIX_NAME}" ]; then \

--- a/tinybuild-apks/aports/libucontext/APKBUILD
+++ b/tinybuild-apks/aports/libucontext/APKBUILD
@@ -1,0 +1,53 @@
+# Maintainer: Ariadne Conill <ariadne@dereferenced.org>
+pkgname=libucontext
+pkgver=1.3.2
+pkgrel=1
+pkgdesc="ucontext function implementations"
+url="https://github.com/kaniini/libucontext"
+arch="all"
+license="ISC"
+subpackages="$pkgname-dev"
+if [ "$BOOTSTRAP" != "nobase" ]; then
+	subpackages="$subpackages $pkgname-doc"
+	makedepends="scdoc"
+fi
+source="
+	https://distfiles.ariadne.space/libucontext/libucontext-$pkgver.tar.xz
+
+	0001-fix-header-install-dir.patch
+	"
+
+case "$CTARGET_ARCH" in
+	arm*)		LIBUCONTEXT_ARCH="arm" ;;
+	ppc64le)	LIBUCONTEXT_ARCH="ppc64" ;;
+	*)		LIBUCONTEXT_ARCH="$CTARGET_ARCH" ;;
+esac
+
+build() {
+	make ARCH="$LIBUCONTEXT_ARCH"
+	if [ "$BOOTSTRAP" != "nobase" ]; then
+		make ARCH="$LIBUCONTEXT_ARCH" docs
+	fi
+}
+
+check() {
+	make ARCH="$LIBUCONTEXT_ARCH" check
+}
+
+package() {
+	case "$BOOTSTRAP" in
+	nobase)
+		# omit pkgconfig files during bootstrap to
+		# avoid auto-tracing a dependency on that
+		make ARCH="$LIBUCONTEXT_ARCH" DESTDIR="$pkgdir" pkgconfigdir=/.omit install
+		;;
+	*)
+		make ARCH="$LIBUCONTEXT_ARCH" DESTDIR="$pkgdir" install install_docs
+		;;
+	esac
+}
+
+sha512sums="
+3911a9a772832dad68dc4dbb78ca646cba92170d4e192948e0a6e78295f6ee27f20b637986d39450edae805c96b08f7e1716fa7904fc84258acab8691d87c4f5  libucontext-1.3.2.tar.xz
+55e2b4f58835bf9305e23623cc77e8a0af752a70920f5922466702dc80abb9d545cbc541c1fcd9dc0f9a4d5bcfc1566d6e46ecc92d79c580fde8c3cdb41d0cad  0001-fix-header-install-dir.patch
+"

--- a/tinybuild-apks/aports/libucontext/src/0001-fix-header-install-dir.patch
+++ b/tinybuild-apks/aports/libucontext/src/0001-fix-header-install-dir.patch
@@ -1,0 +1,1 @@
+/home/maribu/Repos/software/aports/master/main/libucontext/0001-fix-header-install-dir.patch

--- a/tinybuild-apks/aports/libucontext/src/libucontext-1.3.2.tar.xz
+++ b/tinybuild-apks/aports/libucontext/src/libucontext-1.3.2.tar.xz
@@ -1,0 +1,1 @@
+/var/cache/distfiles/libucontext-1.3.2.tar.xz

--- a/tinybuild-apks/src/fixed-rustc.c
+++ b/tinybuild-apks/src/fixed-rustc.c
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: 0BSD
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    static char *rustc = "rustc";
+    static char *fix_linking = "-Ctarget-feature=-crt-static";
+    char **args = calloc(sizeof(char *), argc + 1);
+    if (!args) {
+        puts("calloc() failed");
+        return EXIT_FAILURE;
+    }
+
+    args[0] = rustc;
+    args[1] = fix_linking;
+
+
+    int pos = 1;
+    while (argv[pos] != NULL) {
+        args[pos + 1] = argv[pos];
+        pos++;
+    }
+
+    int retval = execv("/usr/bin/rustup-init", args);
+    printf("execv() failed with: %d\n", retval);
+    return EXIT_FAILURE;
+}

--- a/tinybuild-arm/Dockerfile
+++ b/tinybuild-arm/Dockerfile
@@ -1,0 +1,11 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        newlib-arm-none-eabi \
+        picolibc-arm-none-eabi

--- a/tinybuild-avr/Dockerfile
+++ b/tinybuild-avr/Dockerfile
@@ -1,0 +1,10 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        avr-libc

--- a/tinybuild-base/Dockerfile
+++ b/tinybuild-base/Dockerfile
@@ -1,0 +1,15 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM alpine:latest
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    echo "@riotapks /tinybuild-apks/riotapks" >> /etc/apk/repositories && \
+    cp /tinybuild-apks/*.rsa.pub /etc/apk/keys/ && \
+    apk update && \
+    apk add \
+        python3 \
+        make \
+        unzip \
+        git

--- a/tinybuild-msp430/Dockerfile
+++ b/tinybuild-msp430/Dockerfile
@@ -1,0 +1,10 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        newlib-msp430-elf

--- a/tinybuild-native64/Dockerfile
+++ b/tinybuild-native64/Dockerfile
@@ -1,0 +1,13 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        libucontext-dev@riotapks \
+        gcc \
+        musl-dev \
+        linux-headers

--- a/tinybuild-risc-v/Dockerfile
+++ b/tinybuild-risc-v/Dockerfile
@@ -1,0 +1,11 @@
+ARG DOCKER_REGISTRY="docker.io/riot"
+FROM ${DOCKER_REGISTRY}/tinybuild-base:latest
+
+LABEL maintainer="Marian Buschsieweke <marian.buschsieweke@posteo.net>"
+
+RUN \
+    --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    --mount=type=bind,target=/tinybuild-apks,source=/output,from=tinybuild-apks \
+    apk add \
+        newlib-riscv-none-elf \
+        picolibc-riscv-none-elf


### PR DESCRIPTION
Add tiny build images

This adds Alpine based images intended for use with

    make BUILD_IN_DOCKER=1 DOCKER_IMAGE=docker.io/riot/tinybuild-<ARCH>

This adds the following images:

- tinybuild-native64: C toolchain needed to build RIOT apps for `native64`
- smallbuild-native64: C, C++, and rust toolchain needed to build RIOT apps for `native64`
- tinybuild-arm: C toolchain needed to build RIOT apps for ARM7 & ARM Cortex M boards
- smallbuild-arm: C, C++ and rust toolchain libc needed to build RIOT apps for ARM7 & ARM Cortex M boards
- tinybuild-avr: C and C++ toolchain and AVR libc needed to build RIOT apps for AVR boards
- tinybuild-msp430: C toolchain needed to build RIOT apps for MSP430 boards
- smallbuild-msp430: C and C++ toolchain needed to build RIOT apps for MSP430 boards
- tinybuild-risc-v: C toolchain needed to build RIOT apps for RISC-V boards
- smallbuild-risc-v: C, C++, and rust toolchain needed to build RIOT apps for RISC-V boards

For comparison, this is the size:

```
REPOSITORY                            TAG         IMAGE ID      CREATED            SIZE
docker.io/riot/riotbuild              latest      138e78010e19  4 weeks ago        13.5 GB
localhost/maribu/smallbuild-arm       latest      1fb5420486b7  56 minutes ago     4.23 GB
localhost/maribu/smallbuild-base      latest      a56817ee290e  59 minutes ago     1.74 GB
localhost/maribu/smallbuild-msp430    latest      11e2ecc41466  36 minutes ago     452 MB
localhost/maribu/smallbuild-native64  latest      86a4a333ac44  48 minutes ago     2.39 GB
localhost/maribu/smallbuild-risc-v    latest      a4692906f483  39 minutes ago     3.28 GB
localhost/maribu/tinybuild-arm        latest      d3718b8a6b57  58 minutes ago     1.17 GB
localhost/maribu/tinybuild-avr        latest      41013f963ddc  37 minutes ago     405 MB
localhost/maribu/tinybuild-base       latest      bd9802e90d98  About an hour ago  62.7 MB
localhost/maribu/tinybuild-msp430     latest      9f2c69543069  36 minutes ago     342 MB
localhost/maribu/tinybuild-native64   latest      6d01bf6ebece  51 minutes ago     239 MB
localhost/maribu/tinybuild-risc-v     latest      97066835a715  37 minutes ago     1.06 GB
```

I tested to build `examples/basic/default` for one board with each docker image successfully.