### PR TITLE
gh-actions: add workflow_dispatch trigger for manual builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ on:
     branches:
       - '*'
   merge_group:
+  workflow_dispatch:
 
 jobs:
   build-test:


### PR DESCRIPTION
This should allow us to update the docker registry if, e.g., there is an update to an upstream python package (e.g. `riotctrl`, see https://github.com/RIOT-OS/riotctrl/releases/tag/v0.5.1).