### PR TITLE
tests: Run on native32 as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2025.01-branch'
-      VERSION_TAG: '2025.04'
+      RIOT_BRANCH: '2025.04-branch'
+      VERSION_TAG: '2025.07'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native32 native64 samr21-xpro"
 
       - name: GNU microbit qemu test
         run: >
@@ -127,7 +127,7 @@ jobs:
           TOOLCHAIN: llvm
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-          BOARDS: "native samr21-xpro"
+          BOARDS: "native32 native64 samr21-xpro"
 
       - name: Rust build test
         run: |
@@ -143,7 +143,7 @@ jobs:
           # Not all of them are actually available; still using the "canonical"
           # list of representative boards above to keep this stable whil Rust
           # support expands
-          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native samr21-xpro"
+          BOARDS: "arduino-uno esp32-wroom-32 hifive1b msb-430h native32 native64 samr21-xpro"
 
       - name: C++ build test
         run: |
@@ -151,7 +151,7 @@ jobs:
         env:
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest
-          BOARDS: "esp32-wroom-32 hifive1b native samr21-xpro"
+          BOARDS: "esp32-wroom-32 hifive1b native32 native64 samr21-xpro"
 
       - name: laze test
         run: |


### PR DESCRIPTION
Trouble with [21531] indicates that running tests on native is insufficient to catch native32 trouble; this should catch that kind of issue earlier.

[21531]: https://github.com/RIOT-OS/RIOT/pull/21531

---

Created as a draft PR, because if it succeeds in this stage with only the added testing, it's not doing the right thing yet -- [21531] shows that something about the current container doesn't work on murdock, and this test is supposed to show this early. (I.e., this PR should also get some kind of fix.).