### PR TITLE
riotbuild/Dockerfile: remove unused MIPS toolchain, remove old MSP430 toolchain

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -148,23 +148,6 @@ RUN echo 'Installing arm-none-eabi toolchain from arm.com' >&2 && \
 
 ENV PATH ${PATH}:/opt/${ARM_FOLDER}/bin
 
-# Install MIPS binary toolchain
-# For updates: https://www.mips.com/develop/tools/codescape-mips-sdk/ (select "Codescape GNU Toolchain")
-ARG MIPS_VERSION=2020.06-01
-RUN echo 'Installing mips-mti-elf toolchain from mips.com' >&2 && \
-    mkdir -p /opt && \
-    curl -L "https://codescape.mips.com/components/toolchain/${MIPS_VERSION}/Codescape.GNU.Tools.Package.${MIPS_VERSION}.for.MIPS.MTI.Bare.Metal.CentOS-6.x86_64.tar.gz" -o - \
-        | tar -C /opt -zx && \
-    echo 'Removing documentation and translations' >&2 && \
-    rm -rf /opt/mips-mti-elf/*/share/{doc,info,man,locale} && \
-    echo 'Deduplicating binaries' && \
-    cd /opt/mips-mti-elf/*/mips-mti-elf/bin && \
-    for f in *; do test -f "../../bin/mips-mti-elf-$f" && ln -f "../../bin/mips-mti-elf-$f" "$f"; done && cd -
-
-ENV MIPS_ELF_ROOT /opt/mips-mti-elf/${MIPS_VERSION}
-
-ENV PATH ${PATH}:${MIPS_ELF_ROOT}/bin
-
 # Install RISC-V binary toolchain
 ARG RISCV_VERSION=13.2.0-2
 RUN mkdir -p /opt && \

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -38,7 +38,6 @@ COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 # - update the package index files to latest available version
 # - native platform development and build system functionality (about 400 MB installed)
 # - Cortex-M development (about 550 MB installed), through the gcc-arm-embedded PPA
-# - MSP430 development (about 120 MB installed)
 # - AVR development (about 110 MB installed)
 # - LLVM/Clang build environment (about 125 MB installed)
 # - QEMU
@@ -47,8 +46,8 @@ COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 #  updated base OS image. This can be forced with `--pull` flag.
 # This is all done in a single RUN command to reduce the number of layers and to
 # allow the cleanup to actually save space.
-# Total size without cleaning is approximately 1.525 GB (2016-03-08)
-# After adding the cleanup commands the size is approximately 1.497 GB
+# Total size without cleaning is approximately 1.282 GB (2025-11-04)
+# After adding the cleanup commands the size is approximately 1.0 GB
 ARG LLVM_VERSION=14
 RUN \
     dpkg --add-architecture i386 >&2 && \
@@ -89,10 +88,6 @@ RUN \
         unzip \
         vim-common \
         xsltproc \
-    && echo 'Installing MSP430 toolchain' >&2 && \
-    apt-get -y --no-install-recommends install \
-        gcc-msp430 \
-        msp430-libc \
     && echo 'Installing AVR toolchain' >&2 && \
     apt-get -y --no-install-recommends install \
         gcc-avr \
@@ -345,3 +340,4 @@ ENV RIOTBUILD_BRANCH $RIOTBUILD_BRANCH
 RUN echo "RIOTBUILD_VERSION=$RIOTBUILD_VERSION" > /etc/riotbuild
 RUN echo "RIOTBUILD_COMMIT=$RIOTBUILD_COMMIT" >> /etc/riotbuild
 RUN echo "RIOTBUILD_BRANCH=$RIOTBUILD_BRANCH" >> /etc/riotbuild
+


### PR DESCRIPTION
The MIPS support was removed three years ago from RIOT (https://github.com/RIOT-OS/RIOT/pull/18562), but the toolchain in the Dockerfile remained. This PR removes it.

Perhaps we should wait with the merge until @benpicco is done with the Release though 👀 