### PR TITLE
murdock-worker/Dockerfile: update git-cache-rs to the latest version

### DIFF
--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -29,11 +29,6 @@ RUN pip3 install hiredis
 # install testrunner dependencies
 RUN pip3 install click
 
-# get git-cache-rs binary and set the environment variable for
-# the RIOT package subsystem
-COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-jammy /git-cache /usr/bin/git-cache
-ENV GIT_CACHE_RS /usr/bin/git-cache
-
 # install newer ccache package
 ARG CCACHE_TGZ=ccache-4.7.4-linux-x86_64.tar.xz
 COPY files/${CCACHE_TGZ}  /

--- a/murdock-worker/Dockerfile
+++ b/murdock-worker/Dockerfile
@@ -29,8 +29,9 @@ RUN pip3 install hiredis
 # install testrunner dependencies
 RUN pip3 install click
 
-# get git-cache-rs binary
-COPY --from=ghcr.io/kaspar030/git-cache:0.1.5-jammy /git-cache /usr/bin/git-cache
+# get git-cache-rs binary and set the environment variable for
+# the RIOT package subsystem
+COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-jammy /git-cache /usr/bin/git-cache
 ENV GIT_CACHE_RS /usr/bin/git-cache
 
 # install newer ccache package
@@ -43,6 +44,9 @@ COPY murdock_slave.sh /usr/bin/murdock_slave
 
 # create cache folder
 RUN mkdir -m777 /cache
+
+# remove old git-cache-rs files from before the directory structure changed
+RUN rm -rf /cache/.gitcache/*.git /cache/.gitcache/*.lock
 
 # set cache folder for Download Cache
 ENV DLCACHE_DIR /cache/.dlcache


### PR DESCRIPTION
The `git-cache-rs` version specified in the Dockerfile is very old and does not seem to work anymore?
On my local ThinkPad that acts as a CI worker currently, only `git-cache` files were present but no `git-cache-rs` folders.

```
riotbuild@b84655cf2cf7:/cache/.gitcache$ ls -l
total 520
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10077753813265320433.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 16:38 10077753813265320433.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10223567230215662083.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 14:55 10223567230215662083.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 23 23:55 1022674748962676621.git
-rw-r--r-- 1 riotbuild root    0 Oct 23 23:55 1022674748962676621.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10275685405471410120.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 17:22 10275685405471410120.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10395226093010920096.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 17:23 10395226093010920096.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10412693831896225484.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 17:06 10412693831896225484.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10556324815249665068.git
-rw-r--r-- 1 riotbuild root    0 Apr 20 16:33 10556324815249665068.lock
drwxr-xr-x 7 riotbuild root 4096 Oct 14  2025 10620790921438452123.git
...
```


This PR just bumps the version of `git-cache-rs` to the latest version.

Verified to work on my local machine:
```
riotbuild@d852a7ef1af4:/cache/.gitcache$ ls -l
total 528
drwxr-xr-x  7 riotbuild root 4096 Oct 14  2025 10077753813265320433.git
-rw-r--r--  1 riotbuild root    0 Apr 20 16:38 10077753813265320433.lock
...
drwxr-xr-x  7 riotbuild root 4096 Oct 14  2025 9609903824853689138.git
-rw-r--r--  1 riotbuild root    0 Apr 20 16:34 9609903824853689138.lock
drwxr-xr-x  3 riotbuild root 4096 Apr 20 17:55 git.riot-os.org
drwxr-xr-x 14 riotbuild root 4096 Apr 20 18:04 github.com
```