### PR TITLE
github/workflows: Bump Version and don't pin docker image for static test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,7 +167,9 @@ jobs:
       - name: Run static tests
         run: |
           docker run --rm -t -v $(pwd)/RIOT:/data/riotbuild \
-          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
+          -e CI_BASE_BRANCH=${{ env.RIOT_BRANCH }} \
+          -e ENABLE_DOCKER_PINNING_TEST=0 \
+          ${{ env.DOCKER_REGISTRY }}/riotbuild:latest \
           ./dist/tools/ci/static_tests.sh
 
       - name: Build murdock worker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     env:
-      RIOT_BRANCH: '2025.07-branch'
-      VERSION_TAG: '2025.10'
+      RIOT_BRANCH: '2026.04-branch'
+      VERSION_TAG: '2026.07'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:


### PR DESCRIPTION
Extracted from #265.

The changes utilize the feature from https://github.com/RIOT-OS/RIOT/pull/21815 to avoid the static test failing because of the Docker container ID mismatch.