### PR TITLE
riotdocker/requirements.txt: Reorder, group and document

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -1,20 +1,36 @@
 # Required python libraries
-pyasn1==0.4.2
+# =========================
+#
+# Please try to maintain the alphabetical order of the entries within a
+# category and document their purpose (i.e. the module they're used for).
+
+# RIOT toolchain dependencies
+jinja2==2.11.3              # used by STM32 vector and IRQ file generation
+pexpect==4.8.0              # used by testing infrastructure
+pyserial==3.4               # used by ESP32 toolchain
+riotctrl[rapidjson]>=0.4.0
+scapy>=2.4.3                # used by network tests
+
+# Package and Application dependencies
+
+## mcuboot
 ecdsa==0.13.3
-pexpect==4.8.0
-pycryptodome==3.11.0        # used by mcuboot
-pyserial==3.4
-ed25519==1.4
+pyasn1==0.4.2
+pycryptodome==3.11.0
+
+## pkg/NanoPb
+protobuf==3.18.3
+
+## pkg/emlearn
+emlearn==0.17.1
+joblib==1.3.2
+scipy==1.10.1               # needed by scikit-learn, but newer ones fail with jammy's cython
+scikit-learn==1.4.0
+
+## SUIT and suit-manifest-generator dependencies
 cbor==1.0.0
 cbor2>=5.0.0
 colorama>=0.4.0
 cryptography>=48.0.0
-scapy>=2.4.3
-protobuf==3.18.3
-scipy == 1.10.1            # needed by scikit-learn, but newer ones fail with jammy's cython
-scikit-learn==1.4.0
-joblib==1.3.2
-emlearn==0.17.1
-jinja2==2.11.3
-riotctrl[rapidjson]>=0.4.0
+ed25519==1.4
 pyhsslms>=1.0.0

--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -8,7 +8,7 @@ ed25519==1.4
 cbor==1.0.0
 cbor2>=5.0.0
 colorama>=0.4.0
-cryptography==3.3.2
+cryptography>=48.0.0
 scapy>=2.4.3
 protobuf==3.18.3
 scipy == 1.10.1            # needed by scikit-learn, but newer ones fail with jammy's cython


### PR DESCRIPTION
The `requirements.txt` file has become a bit of a mess, so I dug through history and tried to find out which dependency is used for which purpose and group them accordingly.

Also, I bumped the version of `cryptography` to close #232 and a bunch of security warnings by @dependabot.

The build and test for `tests/sys/suit_manifest` still suceeds and considering that this was after a version jump from 3.3.2 to 48.0.0, I dared to un-pin the version of `cryptography` to avoid a future flood of @dependabot warnings.

I guess we'll see how that'll turn out 🤷‍♂️ 