### PR TITLE
.github/workflows: Check Secrets and update actions for NodeJS 24 Compilance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,17 +61,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           lfs: 'true'
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
         with:
           driver: docker
 
       - name: Build riotdocker-base
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: ./riotdocker-base
           tags: |
@@ -79,7 +79,7 @@ jobs:
             ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.VERSION_TAG }}
 
       - name: Build static-test-tools
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: ./static-test-tools
           tags: |
@@ -95,7 +95,7 @@ jobs:
           echo "RIOTBUILD_VERSION=$(git describe --always)" >> $GITHUB_ENV
 
       - name: Build riotbuild
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: ./riotbuild
           tags: |
@@ -108,7 +108,7 @@ jobs:
             RIOTBUILD_VERSION=${{ env.RIOTBUILD_VERSION }}
 
       - name: Checkout RIOT
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           repository: RIOT-OS/RIOT
           ref: ${{ env.RIOT_BRANCH }}
@@ -191,7 +191,7 @@ jobs:
           ./dist/tools/ci/static_tests.sh
 
       - name: Build murdock worker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: ./murdock-worker
           tags: |
@@ -202,7 +202,7 @@ jobs:
 
       - name: Login to DockerHub
         if: "${{ github.ref == 'refs/heads/master' && needs.check-secret.outputs.secret-configured == 'true' }}"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secret-configured: ${{ steps.secret-exists-check.outputs.defined }}
+    steps:
+      - name: Check if Secret is configured
+        id: secret-exists-check
+        # check if the secrets are configured before running the tasks
+        # see: https://stackoverflow.com/a/70249520
+        shell: bash
+        run: |
+          if [ "${{ secrets.DOCKER_REGISTRY }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   build-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    needs: [check-secret]
     env:
       RIOT_BRANCH: '2026.04-branch'
       VERSION_TAG: '2026.07'
@@ -183,14 +201,14 @@ jobs:
             DOCKER_REGISTRY=${{ env.DOCKER_REGISTRY }}
 
       - name: Login to DockerHub
-        if: "${{ github.ref == 'refs/heads/master' }}"
+        if: "${{ github.ref == 'refs/heads/master' && needs.check-secret.outputs.secret-configured == 'true' }}"
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push Images
-        if: "${{ github.ref == 'refs/heads/master' }}"
+        if: "${{ github.ref == 'refs/heads/master' && needs.check-secret.outputs.secret-configured == 'true' }}"
         run: |
           docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:latest
           docker image push ${{ env.DOCKER_REGISTRY }}/riotdocker-base:${{ env.VERSION_TAG }}


### PR DESCRIPTION
## Contribution

Similar to what I added in https://github.com/RIOT-OS/RIOT/pull/22085, the `riotdocker` workflows should also check if the Docker Hub credentials are set and if not, they shouldn't try to push images.

Before:

<img width="1846" height="937" alt="Screenshot 2026-05-11 154054" src="https://github.com/user-attachments/assets/d8a0e412-58a7-422f-8dfe-a0074d33c3e6" />


After:

<img width="1848" height="927" alt="Screenshot 2026-05-11 160402" src="https://github.com/user-attachments/assets/7f82ad6f-7877-41d8-9cfd-5294f879c474" />

While testing this, I noticed a slight warning, that NodeJS 20 based actions will be forced to run on NodeJS 24 by June 2026 and by September 2026, they will be disabled. See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Testing

I tested it in my fork's `master` branch and it works:
<img width="1843" height="938" alt="image" src="https://github.com/user-attachments/assets/97c22ca0-f059-4023-9da1-1bbc77e0b9db" />
