### PR TITLE
riotbuild: add RV64 rust target

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -292,6 +292,7 @@ RUN \
     rustup component add rust-src && \
     rustup target add i686-unknown-linux-gnu && \
     rustup target add riscv32imac-unknown-none-elf && \
+    rustup target add riscv64imac-unknown-none-elf && \
     rustup target add thumbv7em-none-eabihf && \
     rustup target add thumbv7em-none-eabi && \
     rustup target add thumbv7m-none-eabi && \


### PR DESCRIPTION
In https://github.com/RIOT-OS/RIOT/pull/22548 a new arch was added including Rust support, however, when run via the Murdock the rust target is missing for RV64.
