### PR TITLE
riotbuild/requirements.txt: unpin scipy, update scikit-learn

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -272,11 +272,8 @@ RUN echo 'Installing RIOT MSP430 ELF toolchain' >&2 && \
 ENV PATH=$PATH:/opt/riot-toolchain/msp430-elf/${RIOT_TOOLCHAIN_GCCPKGVER}/bin
 
 # install required python packages from file
-# numpy must be already installed before installing some other requirements (emlearn)
-RUN pip3 install --no-cache-dir numpy==1.22.4
 COPY requirements.txt /tmp/requirements.txt
 RUN echo 'Installing python3 packages' >&2 \
-    && pip3 install --no-cache-dir pybind11 \
     && pip3 install --no-cache-dir -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 

--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -22,10 +22,12 @@ pycryptodome==3.11.0
 protobuf==3.18.3
 
 ## pkg/emlearn
+pybind11
+numpy
 emlearn==0.17.1
 joblib==1.3.2
-scipy==1.10.1               # needed by scikit-learn, but newer ones fail with jammy's cython
-scikit-learn==1.4.0
+scipy
+scikit-learn==1.5.0
 
 ## SUIT and suit-manifest-generator dependencies
 cbor==1.0.0


### PR DESCRIPTION
### Description

This reverts #185 and #234 as the build issues do not seem to be present anymore. A newer version of scipy is required for the update to Ubuntu 26.04 LTS Resolute Raccoon.

I want to incrementally update the packages before doing the big switch to avoid major breakage (ideally).

This also includes (and closes) #272.

### Testing

Building the container:
```
buechse@skyleaf:~/RIOTstuff/riotdocker-incremental-update$ docker build --build-arg DOCKER_REGISTRY=docker.io/library -t riotbuild ./riotbuild/
[+] Building 149.3s (37/37) FINISHED                                                                                                                                                                                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                               0.0s
 => => transferring dockerfile: 13.73kB                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for ghcr.io/kaspar030/git-cache:0.2.8-jammy                                                                                                                                                                                                           0.4s
 => [internal] load metadata for docker.io/kaspar030/laze:0.1.20-jammy                                                                                                                                                                                                             0.6s
 => [internal] load metadata for docker.io/library/static-test-tools:latest                                                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                    0.0s
 => CACHED FROM ghcr.io/kaspar030/git-cache:0.2.8-jammy@sha256:d584c157ce66a826bf5922111ffbcaa02dc3bc29a376d279191a4ed7c2e6701b                                                                                                                                                    0.0s
 => CACHED FROM docker.io/kaspar030/laze:0.1.20-jammy@sha256:84e9987a92a3e7d29b46f29dd51f6fc1e66e339d01973c9bec6c874b0048ec65                                                                                                                                                      0.0s
 => [stage-0  1/28] FROM docker.io/library/static-test-tools:latest                                                                                                                                                                                                                0.0s
 => [internal] load build context                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 1.10kB                                                                                                                                                                                                                                                0.0s
 => CACHED [stage-0  2/28] RUN mkdir /pkgs                                                                                                                                                                                                                                         0.0s
 => CACHED [stage-0  3/28] COPY files/libsocketcan-dev_0.0.11-1_i386.deb /pkgs/libsocketcan-dev_0.0.11-1_i386.deb                                                                                                                                                                  0.0s
 => CACHED [stage-0  4/28] COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb                                                                                                                                                                        0.0s
 => CACHED [stage-0  5/28] RUN     dpkg --add-architecture i386 >&2 &&     echo 'Update the package index files to latest available versions' >&2 &&     apt-get update     && echo 'Installing native toolchain and build system functionality' >&2 &&     apt-get -y --no-insta  0.0s
 => CACHED [stage-0  6/28] RUN echo 'Installing arm-none-eabi toolchain from arm.com' >&2 &&     mkdir -p /opt &&     curl -L -o /opt/gcc-arm-none-eabi.tar.bz2 https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux  0.0s
 => CACHED [stage-0  7/28] RUN mkdir -p /opt &&         wget -q https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz -O-         | tar -C /opt -xz &&     echo 'Removing documentation' >&2  0.0s
 => CACHED [stage-0  8/28] RUN echo 'Installing ESP8266 toolchain' >&2 &&     mkdir -p /opt/esp &&     cd /opt/esp &&     git clone https://github.com/gschorcht/xtensa-esp8266-elf &&     cd xtensa-esp8266-elf &&     git checkout -q 696257c2b43e2a107d3108b2c1ca6d5df3fb1a6f   0.0s
 => CACHED [stage-0  9/28] RUN echo 'Installing ESP32 toolchain for Xtensa' >&2 &&     curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/xtensa-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz | tar -C /opt/esp -xJ &&     pip install --  0.0s
 => CACHED [stage-0 10/28] RUN echo 'Installing ESP32 toolchain for RISC-V' >&2 &&     curl -L https://github.com/espressif/crosstool-NG/releases/download/esp-14.2.0_20241119/riscv32-esp-elf-14.2.0_20241119-x86_64-linux-gnu.tar.xz | tar -C /opt/esp -xJ                       0.0s
 => CACHED [stage-0 11/28] RUN echo 'Installing ESP32 QEMU for Xtensa' >&2 &&     mkdir -p /opt/esp/qemu-xtensa-softmmu &&     curl -L https://github.com/espressif/qemu/releases/download/esp-develop-9.0.0-20240606/qemu-xtensa-softmmu-esp_develop_9.0.0_20240606-x86_64-linux  0.0s
 => CACHED [stage-0 12/28] RUN echo 'Installing ESP32 QEMU for RISC-V' >&2 &&     mkdir -p /opt/esp/qemu-riscv32-softmmu &&     curl -L https://github.com/espressif/qemu/releases/download/esp-develop-9.0.0-20240606/qemu-riscv32-softmmu-esp_develop_9.0.0_20240606-x86_64-lin  0.0s
 => CACHED [stage-0 13/28] RUN echo 'Installing ESP32 GDB for Xtensa' >&2 &&     curl -L https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/xtensa-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz | tar -C /opt/esp -xz                         0.0s
 => CACHED [stage-0 14/28] RUN echo 'Installing ESP32 GDB for RISC-V' >&2 &&     curl -L https://github.com/espressif/binutils-gdb/releases/download/esp-gdb-v14.2_20240403/riscv32-esp-elf-gdb-14.2_20240403-x86_64-linux-gnu.tar.gz | tar -C /opt/esp -xz                        0.0s
 => CACHED [stage-0 15/28] RUN echo 'Building and Installing PicoLIBC' >&2 &&     pip3 install --no-cache-dir meson &&     mkdir -p /usr/src/picolibc &&     cd /usr/src/picolibc/ &&    curl -L -o 1.4.6.tar.gz https://github.com/keith-packard/picolibc/archive/1.4.6.tar.gz &  0.0s
 => CACHED [stage-0 16/28] COPY cross-riscv-none-elf.txt /usr/src/picolibc/picolibc-1.4.6/                                                                                                                                                                                         0.0s
 => CACHED [stage-0 17/28] RUN cd /usr/src/picolibc/picolibc-1.4.6 &&     which riscv-none-elf-gcc &&     ls -al /opt/xpack-riscv-none-elf-gcc-13.2.0-2/bin &&     mkdir build-arm build-riscv build-esp32 &&     cd build-riscv &&     meson .. -Dtests=true -Dmultilib=false -D  0.0s
 => CACHED [stage-0 18/28] RUN rm -rf /usr/src/picolibc                                                                                                                                                                                                                            0.0s
 => CACHED [stage-0 19/28] RUN echo 'Installing RIOT MSP430 ELF toolchain' >&2 &&         wget -q https://github.com/RIOT-OS/toolchains/releases/download/10.1.0-18-20200722112854-64162e7/riot-msp430-elf-10.1.0-18.tgz -O- | tar -C /opt -xz                                     0.0s
 => [stage-0 20/28] COPY requirements.txt /tmp/requirements.txt                                                                                                                                                                                                                    0.0s
 => [stage-0 21/28] RUN echo 'Installing python3 packages' >&2     && pip3 install --no-cache-dir -r /tmp/requirements.txt     && rm /tmp/requirements.txt                                                                                                                        54.6s
 => [stage-0 22/28] RUN     CARGO_HOME=/opt/rustup/.cargo sh -c "    rustup component add rust-src &&     rustup target add i686-unknown-linux-gnu &&     rustup target add riscv32imac-unknown-none-elf &&     rustup target add riscv64imac-unknown-none-elf &&     rustup tar  22.7s
 => [stage-0 23/28] RUN     echo 'Installing C2Rust' >&2 &&     CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --tag v0.19.0 &&     echo 'Cleaning up root-owned crates.io cache' >&2 &&     rm -rf /opt/rustup  67.5s
 => [stage-0 24/28] COPY --from=kaspar030/laze:0.1.20-jammy /laze /usr/bin/laze                                                                                                                                                                                                    0.0s
 => [stage-0 25/28] COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-jammy /git-cache /usr/bin/git-cache                                                                                                                                                                              0.0s
 => [stage-0 26/28] RUN echo "RIOTBUILD_VERSION=unknown" > /etc/riotbuild                                                                                                                                                                                                          0.2s
 => [stage-0 27/28] RUN echo "RIOTBUILD_COMMIT=unknown" >> /etc/riotbuild                                                                                                                                                                                                          0.2s
 => [stage-0 28/28] RUN echo "RIOTBUILD_BRANCH=unknown" >> /etc/riotbuild                                                                                                                                                                                                          0.2s
 => exporting to image                                                                                                                                                                                                                                                             3.1s
 => => exporting layers                                                                                                                                                                                                                                                            3.1s
 => => writing image sha256:dec557229ddd97990d7d4483d2baef316ca4ac60a57993599775d3612977c8a1                                                                                                                                                                                       0.0s
 => => naming to docker.io/library/riotbuild
```

Building `emlearn`:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ rm -rf build/
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ rm -rf tests/pkg/emlearn/bin/
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=dec557229ddd make -C tests/pkg/emlearn/ all test
make: Entering directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/emlearn'
using BOARD="native64" as "native" on a 64-bit system
Launching build container using image "dec557229ddd".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'     -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG=emlearn'  -w '/data/riotbuild/riotbase/tests/pkg/emlearn/' 'dec557229ddd' make     all test
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_emlearn" for "native64" with CPU "native".

Cloning into '/data/riotbuild/riotbase/build/pkg/emlearn'...
done.
HEAD is now at 7a21d49 Release 0.17.1
"make" -C /data/riotbuild/riotbase/pkg/emlearn/
"make" -C /data/riotbuild/riotbase/boards
"make" -C /data/riotbuild/riotbase/boards/common/init
"make" -C /data/riotbuild/riotbase/boards/native64
"make" -C /data/riotbuild/riotbase/boards/common/native
"make" -C /data/riotbuild/riotbase/boards/common/native/drivers
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/core/lib
"make" -C /data/riotbuild/riotbase/cpu/native
"make" -C /data/riotbuild/riotbase/cpu/native/periph
"make" -C /data/riotbuild/riotbase/cpu/native/stdio_native
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/libc
"make" -C /data/riotbuild/riotbase/sys/preprocessor
"make" -C /data/riotbuild/riotbase/sys/stdio
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
   text    data     bss     dec     hex filename
  73033    1080   59128  133241   20879 /data/riotbuild/riotbase/tests/pkg/emlearn/bin/native64/tests_emlearn.elf
/data/riotbuild/riotbase/tests/pkg/emlearn/bin/native64/tests_emlearn.elf  tap0
RIOT native interrupts/signals initialized.
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.10-devel-316-g55250)
Predicted digit: 6
{ "threads": [{ "name": "idle", "stack_size": 16384, "stack_used": 1080 }]}
{ "threads": [{ "name": "main", "stack_size": 20480, "stack_used": 3384 }]}

Process already stopped
make: Nothing to be done for 'test'.
make: Leaving directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/emlearn'
```