### PR TITLE
riotdocker-base,riotbuild: add Python3 Virtual Environment and drop Python2

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -59,7 +59,6 @@ RUN \
         ninja-build \
         parallel \
         protobuf-compiler \
-        python2 \
         python3-setuptools \
         python3-venv \
         python3-wheel \
@@ -102,7 +101,6 @@ RUN \
     && echo 'Installing additional packages required for ESP32 toolchain' >&2 && \
     apt-get -y --no-install-recommends install \
         python3-serial \
-        libpython2.7 \
         telnet \
     && echo 'Installing local packages' >&2 && \
     apt-get install -y --no-install-recommends /pkgs/*.deb \

--- a/riotdocker-base/Dockerfile
+++ b/riotdocker-base/Dockerfile
@@ -17,9 +17,14 @@ RUN \
         python3 \
         python3-dev \
         python3-pip \
+        python3-venv \
         && \
     echo 'Clean up installation files' >&2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# create python environment that allows "pip install" despite PEP 668
+RUN python3 -m venv /local/python-riot
+ENV PATH="/local/python-riot/bin:$PATH"
 
 # compile suid create_user binary
 COPY create_user.c /tmp/create_user.c


### PR DESCRIPTION
Newer Python versions require a Virtual Environment (VENV) for `pip` to work as we know it.

Also, Python2 has been dead for a while and I don't think we need it anymore. @kaspar030 said that the `emlearn` build breaks, but I can't confirm that with this PR. Will have to see when going to Resolute.

Also, the ESP toolchain still works. I guess it was updated in the meantime to not need Python2 anymore.

The code was copied from #239.

### Testing

Container stats (actually based on master, not on my other PRs):
```
buechse@skyleaf:~/RIOTstuff/riotdocker-incremental-update$ docker image list riotbuild
                                                                                                                                                                                                                                                                    i Info →   U  In Use
IMAGE              ID             DISK USAGE   CONTENT SIZE   EXTRA
riotbuild:latest   d5ead6159359       12.5GB             0B
buechse@skyleaf:~/RIOTstuff/riotdocker-incremental-update$ git log --oneline -n5
0cd8410 (HEAD -> pr/python_venv, origin/pr/python_venv) riotbuild/Dockerfile: drop Python2
203a66c riotdocker-base/Dockerfile: add Python3 virtual environment (VENV)
68e0cb9 (origin/master, origin/HEAD, master) Merge pull request #279 from AnnsAnns/rustup_rv64
8202f1d riotbuild: add RV64 rust target
81799d8 Merge pull request #266 from crasbe/pr/fix_usergroup
```

Building `emlearn`:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ rm -rf build/
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ rm -rf tests/pkg/emlearn/bin/

buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=d5ead6159359 make -C tests/pkg/emlearn/ all test
make: Entering directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/emlearn'
using BOARD="native64" as "native" on a 64-bit system
Launching build container using image "d5ead6159359".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'     -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG=emlearn'  -w '/data/riotbuild/riotbase/tests/pkg/emlearn/' 'd5ead6159359' make     all test
using BOARD="native64" as "native" on a 64-bit system
Building application "tests_emlearn" for "native64" with CPU "native".

Cloning into '/data/riotbuild/riotbase/build/pkg/emlearn'...
done.
HEAD is now at 7a21d49 Release 0.17.1
"make" -C /data/riotbuild/riotbase/pkg/emlearn/
"make" -C /data/riotbuild/riotbase/boards
...
"make" -C /data/riotbuild/riotbase/sys/test_utils/print_stack_usage
   text    data     bss     dec     hex filename
  73033    1080   59128  133241   20879 /data/riotbuild/riotbase/tests/pkg/emlearn/bin/native64/tests_emlearn.elf
/data/riotbuild/riotbase/tests/pkg/emlearn/bin/native64/tests_emlearn.elf  tap0
RIOT native interrupts/signals initialized.
RIOT native64 board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2026.10-devel-316-g55250)
Predicted digit: 6
{ "threads": [{ "name": "idle", "stack_size": 16384, "stack_used": 1080 }]}
{ "threads": [{ "name": "main", "stack_size": 20480, "stack_used": 3384 }]}

Process already stopped
make: Nothing to be done for 'test'.
make: Leaving directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/pkg/emlearn'
```

Building for the ESP32-C6:
```
buechse@skyleaf:~/RIOTstuff/riot-upstream/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=d5ead6159359 BOARD=seeedstudio-xiao-esp32c6 make -C tests/sys/shell all
make: Entering directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/sys/shell'
Launching build container using image "d5ead6159359".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=seeedstudio-xiao-esp32c6' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_interactive_sync test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=app_metadata ps shell_builtin_cmd_help_json shell_cmds_default ztimer_msec' -e 'USEPKG='  -w '/data/riotbuild/riotbase/tests/sys/shell/' 'd5ead6159359' make     all
Building application "tests_shell" for "seeedstudio-xiao-esp32c6" with CPU "esp32".

Cloning into '/data/riotbuild/riotbase/build/pkg/esp32_sdk'...
done.
Updating files: 100% (15687/15687), done.
HEAD is now at c8bb53292d0 Merge branch 'fix/return_esp_err_t_for_httpd_req_get_url_query_str_v5.4' into 'release/v5.4'
"make" -C /data/riotbuild/riotbase/pkg/esp32_sdk/
...
"make" -C /data/riotbuild/riotbase/cpu/esp32/bootloader
Generating bootloader image /data/riotbuild/riotbase/tests/sys/shell/bin/seeedstudio-xiao-esp32c6/esp_bootloader/bootloader.bin
esptool v5.0.0
Creating ESP32C6 image...
Merged 1 ELF section.
Successfully created ESP32C6 image.
"make" -C /data/riotbuild/riotbase/cpu/esp32/esp-idf
...
"make" -C /data/riotbuild/riotbase/sys/ztimer
esptool v5.0.0
Creating ESP32C6 image...
Merged 2 ELF sections.
Successfully created ESP32C6 image.
# append size of /data/riotbuild/riotbase/tests/sys/shell/bin/seeedstudio-xiao-esp32c6/tests_shell.elf.bin
Parsing CSV input...
   text    data     bss     dec     hex filename
  80420   78064   97042  255526   3e626 /data/riotbuild/riotbase/tests/sys/shell/bin/seeedstudio-xiao-esp32c6/tests_shell.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-upstream/RIOT/tests/sys/shell'
```