### PR TITLE
riotbuild/Dockerfile: update C2Rust to v0.22.1

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -298,7 +298,7 @@ RUN \
 
 RUN \
     echo 'Installing C2Rust' >&2 && \
-    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --tag v0.19.0 && \
+    CARGO_HOME=/opt/rustup/.cargo cargo install --no-track --locked c2rust --git https://github.com/immunant/c2rust --tag v0.22.1 && \
     echo 'Cleaning up root-owned crates.io cache' >&2 && \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 


### PR DESCRIPTION
Ubuntu 26.04 LTS ships with a newer version of CMake (newer than 3.5) and the `CMakeLists.txt` in `c2rust-ast-exporter` got updated in version v0.21.0.

I took the opportunity to go to the latest version.

See this log:

```
49.89    Compiling c2rust-ast-exporter v0.19.0 (/opt/rustup/.cargo/git/checkouts/c2rust-2471865f8518dc65/b9339f4/c2rust-ast-exporter)
50.25 error: failed to run custom build command for `c2rust-ast-exporter v0.19.0 (/opt/rustup/.cargo/git/checkouts/c2rust-2471865f8518dc65/b9339f4/c2rust-ast-exporter)`
50.25
50.25 Caused by:
50.25   process didn't exit successfully: `/tmp/cargo-installoNxaJk/release/build/c2rust-ast-exporter-e49da0d2d62b9f9d/build-script-build` (exit status: 101)
50.25   --- stdout
50.25   CMAKE_TOOLCHAIN_FILE_x86_64-unknown-linux-gnu = None
50.25   CMAKE_TOOLCHAIN_FILE_x86_64_unknown_linux_gnu = None
50.25   HOST_CMAKE_TOOLCHAIN_FILE = None
50.25   CMAKE_TOOLCHAIN_FILE = None
50.25   CMAKE_GENERATOR_x86_64-unknown-linux-gnu = None
50.25   CMAKE_GENERATOR_x86_64_unknown_linux_gnu = None
50.25   HOST_CMAKE_GENERATOR = None
50.25   CMAKE_GENERATOR = None
50.25   CMAKE_PREFIX_PATH_x86_64-unknown-linux-gnu = None
50.25   CMAKE_PREFIX_PATH_x86_64_unknown_linux_gnu = None
50.25   HOST_CMAKE_PREFIX_PATH = None
50.25   CMAKE_PREFIX_PATH = None
50.25   CMAKE_x86_64-unknown-linux-gnu = None
50.25   CMAKE_x86_64_unknown_linux_gnu = None
50.25   HOST_CMAKE = None
50.25   CMAKE = None
50.25   running: cd "/tmp/cargo-installoNxaJk/release/build/c2rust-ast-exporter-e00e03791d855384/out/build" && CMAKE_PREFIX_PATH="" "cmake" "/opt/rustup/.cargo/git/checkouts/c2rust-2471865f8518dc65/b9339f4/c2rust-ast-exporter/src" "-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm" "-DClang_DIR=/usr/lib/llvm-17/lib/cmake/clang" "-DCMAKE_INSTALL_PREFIX=/tmp/cargo-installoNxaJk/release/build/c2rust-ast-exporter-e00e03791d855384/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_ASM_COMPILER=/usr/bin/cc" "-DCMAKE_BUILD_TYPE=Release"
50.25   -- Configuring incomplete, errors occurred!
50.25
50.25   --- stderr
50.25   CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
50.25     Compatibility with CMake < 3.5 has been removed from CMake.
50.25
50.25     Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
50.25     to tell CMake that the project requires at least <min> but has been updated
50.25     to work with policies introduced by <max> or earlier.
50.25
50.25     Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

### Testing

The build of `rust-hello-world` seems to fail for `native`, although it is not exluded (as it is in `rust-gcoap`):
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=4ba02f7d83982 make -C examples/lang_support/official/rust-hello-world/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/official/rust-hello-world'
using BOARD="native64" as "native" on a 64-bit system
Launching build container using image "4ba02f7d83982".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaice/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'     -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world/' '4ba02f7d83982' make
using BOARD="native64" as "native" on a 64-bit system
Building application "hello-world" for "native64" with CPU "native".

"make" -C /data/riotbuild/riotbase/boards compile-commands
...
"make" -C /data/riotbuild/riotbase/sys/preprocessor compile-commands
make[3]: Nothing to be done for 'compile-commands'.
"make" -C /data/riotbuild/riotbase/sys/stdio compile-commands
   Compiling proc-macro2 v1.0.93
...
   Compiling riot-sys v0.7.15 (https://github.com/RIOT-OS/rust-riot-sys#88d87768)
error: proc-macro derive panicked
   --> /data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world/bin/native64/target/x86_64-unknown-linux-gnu/release/build/riot-sys-7ae7c20e2a60a7e2/out/riot_c2rust_replaced.rs:518:23
    |
518 | #[derive(Copy, Clone, BitfieldStruct)]
    |                       ^^^^^^^^^^^^^^
    |
    = help: message: `""` is not a valid identifier

error: could not compile `riot-sys` (lib) due to 1 previous error
make: *** [/data/riotbuild/riotbase/makefiles/cargo-targets.inc.mk:63: /data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world/bin/native64/target/x86_64-unknown-linux-gnu/release/librust_hello_world.a] Error 101
make: *** [/home/buechse/RIOTstuff/riot-vanillaice/RIOT/makefiles/docker.inc.mk:397: ..in-docker-container] Error 2
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/official/rust-hello-world'
```

I would assume this is related to https://github.com/RIOT-OS/rust-riot-sys/pull/65 ?


Compiling for a different board works fine:
```
buechse@skyleaf:~/RIOTstuff/riot-vanillaice/RIOT$ BUILD_IN_DOCKER=1 DOCKER_IMAGE=4ba02f7d83982 BOARD=nrf52840dk make -C examples/lang_support/official/rust-hello-world/
make: Entering directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/official/rust-hello-world'
Launching build container using image "4ba02f7d83982".
docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-vanillaice/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'    -e 'BOARD=nrf52840dk' -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=' -e 'USEPKG='  -w '/data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world/' '4ba02f7d83982' make
Building application "hello-world" for "nrf52840dk" with CPU "nrf52".

"make" -C /data/riotbuild/riotbase/boards compile-commands
...
"make" -C /data/riotbuild/riotbase/sys/preprocessor compile-commands
make[3]: Nothing to be done for 'compile-commands'.
"make" -C /data/riotbuild/riotbase/sys/stdio compile-commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart compile-commands
   Compiling proc-macro2 v1.0.93
   Compiling unicode-ident v1.0.14
...
   Compiling pin-project v1.1.8
   Compiling riot-sys v0.7.15 (https://github.com/RIOT-OS/rust-riot-sys#88d87768)
   Compiling rust-hello-world v0.1.0 (/data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world)
    Finished `release` profile [optimized] target(s) in 14.91s
"make" -C /data/riotbuild/riotbase/pkg/cmsis/
"make" -C /data/riotbuild/riotbase/pkg/mpaland-printf/
"make" -C /data/riotbuild/riotbase/build/pkg/mpaland-printf -f /data/riotbuild/riotbase/pkg/mpaland-printf/mpaland-printf.mk
"make" -C /data/riotbuild/riotbase/boards
...
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text    data     bss     dec     hex filename
   7728       0    2320   10048    2740 /data/riotbuild/riotbase/examples/lang_support/official/rust-hello-world/bin/nrf52840dk/hello-world.elf
make: Leaving directory '/home/buechse/RIOTstuff/riot-vanillaice/RIOT/examples/lang_support/official/rust-hello-world'
```