### PR TITLE
riotbuild/requirements.txt: remove ed25519

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -32,5 +32,4 @@ cbor==1.0.0
 cbor2>=5.0.0
 colorama>=0.4.0
 cryptography>=48.0.0
-ed25519==1.4
 pyhsslms>=1.0.0


### PR DESCRIPTION
The `ed25519` dependency has been added in #73 for SUIT `draft-moran-v4` in https://github.com/RIOT-OS/RIOT/pull/11818, however the support for that has been removed in https://github.com/RIOT-OS/RIOT/pull/13486.

Since then the `ed25519` package was not required anymore and now causes build issues with the update to Ubuntu 26.04 LTS.
The `ed25519` package is not maintained anymore and depends on `versioneer` which is not maintained anymore either and causes a build failure:
```
65.98 Collecting ed25519==1.4 (from -r /tmp/requirements.txt (line 37))
66.00   Downloading ed25519-1.4.tar.gz (866 kB)
66.01      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 866.4/866.4 kB 128.0 MB/s eta 0:00:00
66.04   Installing build dependencies: started
66.62   Installing build dependencies: finished with status 'done'
66.62   Getting requirements to build wheel: started
66.91   Getting requirements to build wheel: finished with status 'error'
66.91   error: subprocess-exited-with-error
66.91
66.91   × Getting requirements to build wheel did not run successfully.
66.91   │ exit code: 1
66.91   ╰─> [33 lines of output]
66.91       /tmp/pip-install-x25yk91m/ed25519_c9b138c359ca4d269e2b8eb0b9986b1f/versioneer.py:587: SyntaxWarning: "\s" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\s"? A raw string is also an option.
66.91         mo = re.search(r'=\s*"(.*)"', line)
66.91       Traceback (most recent call last):
66.91         File "/local/python-riot/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
66.91           main()
66.91           ~~~~^^
66.91         File "/local/python-riot/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
66.91           json_out["return_val"] = hook(**hook_input["kwargs"])
66.91                                    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
66.91         File "/local/python-riot/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
66.91           return hook(config_settings)
66.91         File "/tmp/pip-build-env-ianufgey/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
66.91           return self._get_build_requires(config_settings, requirements=[])
66.91                  ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
66.91         File "/tmp/pip-build-env-ianufgey/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
66.91           self.run_setup()
66.91           ~~~~~~~~~~~~~~^^
66.91         File "/tmp/pip-build-env-ianufgey/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
66.91           super().run_setup(setup_script=setup_script)
66.91           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
66.91         File "/tmp/pip-build-env-ianufgey/overlay/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
66.91           exec(code, locals())  # noqa: S102 # exec is intentional here
66.91           ~~~~^^^^^^^^^^^^^^^^
66.91         File "<string>", line 104, in <module>
66.91         File "/tmp/pip-install-x25yk91m/ed25519_c9b138c359ca4d269e2b8eb0b9986b1f/versioneer.py", line 1405, in get_version
66.91           return get_versions()["version"]
66.91                  ~~~~~~~~~~~~^^
66.91         File "/tmp/pip-install-x25yk91m/ed25519_c9b138c359ca4d269e2b8eb0b9986b1f/versioneer.py", line 1339, in get_versions
66.91           cfg = get_config_from_root(root)
66.91         File "/tmp/pip-install-x25yk91m/ed25519_c9b138c359ca4d269e2b8eb0b9986b1f/versioneer.py", line 399, in get_config_from_root
66.91           parser = configparser.SafeConfigParser()
66.91                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
66.91       AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
```