### PR TITLE
{riotbuild,static-test-tools}/Dockerfile: remove old dependencies

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -51,7 +51,6 @@ RUN \
         gdb \
         g++-multilib \
         libffi-dev \
-        libpcre3 \
         libtool \
         libsdl2-dev \
         libsdl2-dev:i386 \

--- a/static-test-tools/Dockerfile
+++ b/static-test-tools/Dockerfile
@@ -25,7 +25,6 @@ RUN \
         graphviz \
         less \
         make \
-        pcregrep \
         shellcheck \
         vera++ \
         wget \


### PR DESCRIPTION
These have been present since the initial commit 12 years ago:
<img width="679" height="295" alt="image" src="https://github.com/user-attachments/assets/95ff8437-e2ac-45fa-aeec-413afaa71fe8" />

I have tried to find where they are used or if they are used at all, but they don't seem to be anymore.
`pcregep` was a requirement for the ESP8266 toolchain, but I don't think it is anymore (as it happily builds without):
<img width="1126" height="550" alt="image" src="https://github.com/user-attachments/assets/9890c85c-411f-4075-8c5a-e7309f549a77" />
