### PR TITLE
.github/workflows: build master branch of RIOT, bump container version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check-secret]
     env:
-      RIOT_BRANCH: '2026.04-branch'
-      VERSION_TAG: '2026.07'
+      RIOT_BRANCH: 'master'
+      VERSION_TAG: '2026.10'
       DOCKER_REGISTRY: "${{ secrets.DOCKER_REGISTRY || 'local' }}"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -76,3 +76,14 @@ or test of your liking:
 ```sh
 BUILD_IN_DOCKER=1 DOCKER_IMAGE=f610ef8e4bbd BOARD=nrf52840dk make -C tests/sys/shell
 ```
+
+## Notes for Release Managers
+
+The version in `.github/workflows/build.yml` has to be advanced on every RIOT
+release and be ahead of the RIOT release. For example, when RIOT 2026.07 was
+released, the version for the docker container has to be advanced to 2026.10.
+
+By advancing the version, the image version matching the RIOT release version
+on the Docker Hub will not be changed anymore by changes to the container
+repository and therefore will not cause issues with the Buildsystem Sanity
+Check of RIOT.


### PR DESCRIPTION
### Contribution Description

In my opinion, the build test of the docker containers should always build the latest `master` branch of RIOT instead of the Release branch, as any changes to the RIOT repository (such as the ones made for #285), are not pulled in for the build test.

Furthermore, I would like to detach the version number of the Docker container from the RIOT release version. This would make it possible to pin the Docker container version in the Releases of RIOT and avoid having to update and backport them when an update in the Docker container happens.

This might require some additional logic in `makefiles/docker.inc.mk`, but I'll have to check that.

### Related Issues

This closes #84.