### PR TITLE
riotbuild/requirements.txt: bump protobuf version for nanopb

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -19,7 +19,7 @@ pyasn1==0.4.2
 pycryptodome==3.11.0
 
 ## pkg/NanoPb
-protobuf==3.18.3
+protobuf==7.36.0
 
 ## pkg/emlearn
 pybind11


### PR DESCRIPTION
The dependency resolution in the Python version used by Resolute does not seem to include all the necessary dependencies anymore, so the build fails. This is also a good opportunity to update the version in general and close some security advisories.

Replaces #274.