### PR TITLE
riotbuild/requirements: remove unused jinja2 dependency

### DIFF
--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -5,7 +5,6 @@
 # category and document their purpose (i.e. the module they're used for).
 
 # RIOT toolchain dependencies
-jinja2==2.11.3              # used by STM32 vector and IRQ file generation
 pexpect==4.8.0              # used by testing infrastructure
 pyserial==3.4               # used by ESP32 toolchain
 riotctrl[rapidjson]>=0.4.0


### PR DESCRIPTION
Before the PR that generates the STM32 IRQ and vector files https://github.com/RIOT-OS/RIOT/pull/14595 was merged, the approach was changed and `jinja2` was not actually used for it. At that point, https://github.com/RIOT-OS/riotdocker/pull/113 was already merged and therefore it remained in the requirements list, even though it wasn't actually used.

This PR closes four security advisories as well as #270 from @dependabot.

This also reverts #113.