### PR TITLE
riotbuild/Dockerfile: set `laze` and `git-cache` version tags to `resolute`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
           # Some of the above are executed by root, creating ~/.cargo/git as
           # that user, blocking downloads of own libraries.
           rm -rf ~/.cargo
-          RIOT/dist/tools/compile_test/compile_like_murdock.py -a $APPLICATIONS -b $BOARDS -t $TOOLCHAIN -j16
+          RIOT/dist/tools/compile_test/compile_like_murdock.py -a $APPLICATIONS -b $BOARDS -t $TOOLCHAIN -j16 -vvv
         env:
           BUILD_IN_DOCKER: 1
           DOCKER_IMAGE: ${{ env.DOCKER_REGISTRY }}/riotbuild:latest

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -74,7 +74,7 @@ RUN \
         ssh-client \
         subversion \
         unzip \
-        vim-common \
+        xxd \
         xsltproc \
     && echo 'Installing AVR toolchain' >&2 && \
     apt-get -y --no-install-recommends install \

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -30,7 +30,7 @@ COPY files/libsocketcan2_0.0.11-1_i386.deb /pkgs/libsocketcan2_0.0.11-1_i386.deb
 #  updated base OS image. This can be forced with `--pull` flag.
 # This is all done in a single RUN command to reduce the number of layers and to
 # allow the cleanup to actually save space.
-ARG LLVM_VERSION=15
+ARG LLVM_VERSION=17
 RUN \
     dpkg --add-architecture i386 >&2 && \
     echo 'Update the package index files to latest available versions' >&2 && \
@@ -298,11 +298,11 @@ RUN \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 
 # get laze binary
-COPY --from=kaspar030/laze:0.1.20-jammy /laze /usr/bin/laze
+COPY --from=kaspar030/laze:0.1.20-ubuntu /laze /usr/bin/laze
 
 # get git-cache-rs binary and set the environment variable for
 # the RIOT package subsystem
-COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-jammy /git-cache /usr/bin/git-cache
+COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-ubuntu /git-cache /usr/bin/git-cache
 ENV GIT_CACHE_RS=/usr/bin/git-cache
 
 # get Dockerfile version from build args

--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -298,11 +298,11 @@ RUN \
     rm -rf /opt/rustup/.cargo/{git,registry,.package-cache}
 
 # get laze binary
-COPY --from=kaspar030/laze:0.1.20-ubuntu /laze /usr/bin/laze
+COPY --from=kaspar030/laze:0.1.20-resolute /laze /usr/bin/laze
 
 # get git-cache-rs binary and set the environment variable for
 # the RIOT package subsystem
-COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-ubuntu /git-cache /usr/bin/git-cache
+COPY --from=ghcr.io/kaspar030/git-cache:0.2.8-resolute /git-cache /usr/bin/git-cache
 ENV GIT_CACHE_RS=/usr/bin/git-cache
 
 # get Dockerfile version from build args

--- a/riotbuild/requirements.txt
+++ b/riotbuild/requirements.txt
@@ -18,7 +18,7 @@ pyasn1==0.6.4
 pycryptodome==3.23.0
 
 ## pkg/NanoPb
-protobuf==3.18.3
+protobuf==7.36.0
 
 ## pkg/emlearn
 pybind11

--- a/riotdocker-base/Dockerfile
+++ b/riotdocker-base/Dockerfile
@@ -3,7 +3,7 @@
 # This container sets the foundation for all subsequent containers and
 # initializes the user environment.
 
-FROM ubuntu:jammy
+FROM ubuntu:resolute
 
 LABEL maintainer="Kaspar Schleiser <kaspar@riot-os.org>"
 


### PR DESCRIPTION
This is a follow-up for #286 once https://github.com/kaspar030/git-cache-rs/pull/144 and https://github.com/kaspar030/laze/pull/902 are merged.

This will pin the versions of `laze` and `git-cache` to `resolute` instead of `ubuntu latest`, which will change with every new Ubuntu release.