### PR TITLE
static-test-tools/requirements.txt: unpin flake8

### DIFF
--- a/static-test-tools/requirements.txt
+++ b/static-test-tools/requirements.txt
@@ -1,4 +1,4 @@
 # Required python libraries for static tests
-flake8==3.8.4
+flake8
 codespell>=1.17.1
 PyYAML==6.0.1


### PR DESCRIPTION
The old version of `flake8` from 2020 does not seem to be compatible with the new Python 3.14 version used by Ubuntu 26.04 LTS anymore. Considering stuff like that is rarely updated, I'd just unpin it and risk creating static errors in `RIOT` instead of having to fix a bunch after 6 years.

PSA: This will create static errors in the main repo, but with the `github annotate` functionality, this should not hold any PRs:

```
buechse@skyleaf:~/RIOTstuff/riot-upstream3/RIOT$ docker run --rm --tty --user $(id -u):$(id -g) --platform linux/amd64 -v '/home/buechse/RIOTstuff/riot-upstream3/RIOT:/data/riotbuild/riotbase:delegated' -v '/home/buechse/.cargo/registry:/data/riotbuild/.cargo/registry:delegated' -v '/home/buechse/.cargo/git:/data/riotbuild/.cargo/git:delegated' -e 'TZ=Europe/Berlin' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'BUILD_IN_DOCKER=0' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles' -v '/home/buechse/.gitcache:/data/riotbuild/gitcache:delegated' -e 'GIT_CACHE_DIR=/data/riotbuild/gitcache'     -e 'DISABLE_MODULE=' -e 'DEFAULT_MODULE=test_utils_print_stack_usage' -e 'FEATURES_REQUIRED=' -e 'FEATURES_BLACKLIST=' -e 'FEATURES_OPTIONAL=' -e 'USEMODULE=app_metadata ps shell_builtin_cmd_help_json shell_cmds_default ztimer_msec' -e 'USEPKG='  -w '/data/riotbuild/riotbase' 1f1a9afe8088a ./dist/tools/flake8/check.sh
<unknown>:88: SyntaxWarning: "\ " is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\ "? A raw string is also an option.
<unknown>:88: SyntaxWarning: "\ " is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\ "? A raw string is also an option.
There are style issues in the following Python scripts:

dist/tools/mkconstfs/mkconstfs2.py:124:40: E741 ambiguous variable name 'l'
dist/tools/pktbuf-stats/pktbuf-stats.py:248:5: F824 `global PKTSNIP_STRUCT` is unused: name is never assigned in scope
dist/tools/pktbuf-stats/pktbuf-stats.py:248:5: F824 `global NETTYPE_STRUCTS` is unused: name is never assigned in scope
dist/tools/pktbuf-stats/pktbuf-stats.py:592:5: F824 `global NETTYPE_STRUCTS` is unused: name is never assigned in scope
dist/tools/pktbuf-stats/pktbuf-stats.py:652:5: F824 `global PKTSNIP_STRUCT` is unused: name is never assigned in scope
dist/tools/pyterm/pyterm:800:11: E275 missing whitespace after keyword
dist/tools/pyterm/testbeds/testbeds.py:163:15: E275 missing whitespace after keyword
doc/doxygen/generate-changelog.py:40:23: E275 missing whitespace after keyword
tests/core/thread_msg_block_race/tests/01-run.py:18:11: E275 missing whitespace after keyword
tests/net/emcute/tests-as-root/01-run.py:321:23: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:85:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:86:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:87:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:88:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:99:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:100:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:101:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:102:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:115:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:116:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:117:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext/tests-as-root/01-run.py:118:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:312:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:365:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:374:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:375:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:376:11: E275 missing whitespace after keyword
tests/net/gnrc_ipv6_ext_frag/tests-as-root/01-run.py:377:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:163:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:164:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:165:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:166:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:176:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:177:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:178:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:179:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:197:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:215:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:228:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:229:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:230:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:231:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:250:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:252:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:253:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:254:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:255:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:256:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:257:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:258:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:278:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:280:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:281:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:282:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:283:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:284:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:285:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:286:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:319:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:320:11: E275 missing whitespace after keyword
tests/net/gnrc_rpl_srh/tests-as-root/01-run.py:321:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:64:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:65:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:66:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:68:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:71:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:72:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:73:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:75:19: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:150:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:156:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:161:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:167:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:179:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:191:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:199:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:205:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:213:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:222:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:235:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:246:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:258:11: E275 missing whitespace after keyword
tests/net/gnrc_sock_dns/tests-with-config/01-run.py:270:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:42:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:43:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:44:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:45:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:49:11: E275 missing whitespace after keyword
tests/net/socket_zep/tests/01-run.py:50:11: E275 missing whitespace after keyword
tests/pkg/semtech-loramac/tests-with-config/01-run.py:180:7: E275 missing whitespace after keyword
tests/riotboot/tests/01-run.py:28:15: E275 missing whitespace after keyword
tests/riotboot/tests/01-run.py:29:15: E275 missing whitespace after keyword
```

That'll be another point for https://github.com/RIOT-OS/RIOT/issues/22216 I guess...