### PR TITLE
riotbuild/Dockerfile: add clang-format

### DIFF
--- a/riotbuild/Dockerfile
+++ b/riotbuild/Dockerfile
@@ -41,6 +41,7 @@ RUN \
         llvm-${LLVM_VERSION}-dev \
         clang-${LLVM_VERSION} \
         clang-tools-${LLVM_VERSION} \
+        clang-format-${LLVM_VERSION} \
         libclang-${LLVM_VERSION}-dev \
         lld-${LLVM_VERSION} \
     && echo 'Installing native toolchain and build system functionality' >&2 && \


### PR DESCRIPTION
@AnnsAnns needs `clang-format` for https://github.com/RIOT-OS/RIOT/pull/22679, so this PR adds it to the dependency list.